### PR TITLE
chore: Enabled SSE by default for the quickstart orchestrator

### DIFF
--- a/src/quickstart.ts
+++ b/src/quickstart.ts
@@ -40,6 +40,7 @@ import type { NFEventRegistry } from 'lib/1.domain/registry/event-registry.contr
   await initFederation(manifest, {
     logger: consoleLogger,
     logLevel: 'warn',
+    sse: true,
     ...useShimImportMap({ shimMode: false }),
   }).then(loaders => {
     if ((window as any).__NF_REGISTRY__ !== undefined) {


### PR DESCRIPTION
This pull request makes a small update to the initialization of federation in `src/quickstart.ts` by enabling server-sent events (SSE) support. The change adds the `sse: true` option to the `initFederation` call, which may improve real-time communication capabilities in the application.