### PR TITLE
fix(configuration): Override from proper config flag

### DIFF
--- a/src/lib/4.config/mode/mode.config.ts
+++ b/src/lib/4.config/mode/mode.config.ts
@@ -15,7 +15,7 @@ export const createModeConfig = (override: ModeOptions): ModeConfig => {
           strictRemoteEntry: override.strict?.strictRemoteEntry ?? false,
           strictExternalCompatibility: override.strict?.strictExternalCompatibility ?? false,
           strictExternalSameVersionCompatibility:
-            override.strict?.strictExternalCompatibility ?? false,
+            override.strict?.strictExternalSameVersionCompatibility ?? false,
           strictExternalVersion: override.strict?.strictExternalVersion ?? false,
           strictImportMap: override.strict?.strictImportMap ?? false,
         };


### PR DESCRIPTION
Closes #9 

This pull request corrects a configuration assignment in the `createModeConfig` function to ensure that the `strictExternalSameVersionCompatibility` property is set from the correct override option.

- Configuration Fix:
  * In `mode.config.ts`, updated the assignment for `strictExternalSameVersionCompatibility` to use `override.strict?.strictExternalSameVersionCompatibility` instead of incorrectly duplicating the `strictExternalCompatibility` option.