### PR TITLE
chore(docs): Updated to match v4 spec

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,11 +75,17 @@ Each micro frontend provides a **remoteEntry.json** file that describes its avai
   "shared": [
     {
       "packageName": "react",
+      "outFileName": "react.js",
       "version": "18.2.0",
       "requiredVersion": "^18.0.0",
-      "singleton": true
+      "singleton": true,
+      "strictVersion": true,
+      "bundle": "browser-react"
     }
-  ]
+  ],
+  "chunks": {
+    "browser-react": ["chunk-ABCD1234.js"]
+  }
 }
 ```
 
@@ -88,6 +94,7 @@ Each micro frontend provides a **remoteEntry.json** file that describes its avai
 - **name**: The name of the remote
 - **exposes**: Available components for consumption
 - **shared**: Dependencies that can be shared with other micro frontends, also referred to as "externals".
+- **chunks**: Optional map of bundle names to the internal chunk files that back those bundles. Used to wire up internal imports so that shared externals resolve their transitive chunks without duplicate downloads (see [Shared Chunks](#shared-chunks)).
 
 ### 3. Optimized Dependency Resolution
 
@@ -153,6 +160,7 @@ classDiagram
         name: string
         exposes: ExposesInfo[]
         shared: SharedInfo[]
+        chunks?: Map<.string, string[]>
     }
     class ExposesInfo{
         key: string
@@ -167,6 +175,7 @@ classDiagram
         packageName: string
         outFileName: string
         shareScope?: string
+        bundle?: string
         dev?: object
     }
 ```
@@ -184,7 +193,8 @@ classDiagram
       "strictVersion": false,
       "singleton": true,
       "packageName": "dep-a",
-      "outFileName": "dep-a.js"
+      "outFileName": "dep-a.js",
+      "bundle": "browser-dep-a"
     },
     {
       "version": "4.5.6",
@@ -194,7 +204,11 @@ classDiagram
       "packageName": "dep-b",
       "outFileName": "dep-b.js"
     }
-  ]
+  ],
+  "chunks": {
+    "browser-dep-a": ["chunk-ABCD1234.js"],
+    "mapping-or-exposed": []
+  }
 }
 ```
 
@@ -209,7 +223,31 @@ classDiagram
 | shareScope      | Allows for sharing dependencies in a specific group instead of globally, allowing for clusters of shared externals. the `"strict"` shareScope is a special scope. |
 | packageName     | Dependency identifier for resolution                                                                                                                              |
 | outFileName     | File path relative to the micro frontend's scope                                                                                                                  |
+| bundle          | Optional name of the internal chunk bundle this external belongs to. Resolves via the `chunks` map on the same remoteEntry (see [Shared Chunks](#shared-chunks)). |
 | dev             | Optional development configuration containing entryPoint information                                                                                              |
+
+#### <a id="shared-chunks"></a> Shared Chunks
+
+When `@softarc/native-federation` builds a remote it may split the shared externals (and exposed modules) into several internal chunks for code-sharing reasons. These chunks don't correspond to an npm package name, but the shared externals still need to resolve imports into them.
+
+The `chunks` map on the remoteEntry.json links a logical **bundle name** (e.g. `browser-angular_common`) to the list of chunk files that make up that bundle:
+
+```json
+{
+  "chunks": {
+    "browser-angular_common": ["chunk-KNRTCTBX.js"],
+    "browser-angular_core": [
+      "chunk-LMMPSTGA.js",
+      "chunk-EFELGE5F.js"
+    ],
+    "mapping-or-exposed": []
+  }
+}
+```
+
+Each shared external that belongs to a bundle references it through its `bundle` property (e.g. `"bundle": "browser-angular_common"`). During import-map generation the orchestrator looks up the chunk files for every bundle referenced by a shared or scoped external on that remote and adds them to the remote's scope as `@nf-internal/<chunk-name>` entries, so the bundled code can resolve its internal imports against the remote that actually served them.
+
+The `mapping-or-exposed` bundle is always implicitly registered for every remote, it contains chunks shared between the exposed modules and the mappings (shared externals) of a single remote.
 
 ### Understanding the stored remoteEntries
 
@@ -291,6 +329,7 @@ classDiagram
         strictVersion: boolean
         cached: boolean
         name: string
+        bundle?: string
     }
     class ScopedExternals {
         Map<.string, ScopedExternal>
@@ -301,6 +340,7 @@ classDiagram
     class ScopedVersion{
         tag: string
         file: string
+        bundle?: string
     }
 ```
 
@@ -418,7 +458,10 @@ The final import map provides the browser with optimized module resolution instr
     // Scoped externals
     "https://example.org/mfe1/": {
       "dep-b": "https://example.org/mfe1/dep-b.js",
-      "dep-c": "https://example.org/mfe1/dep-c.js"
+      "dep-c": "https://example.org/mfe1/dep-c.js",
+
+      // Chunks backing the bundles referenced by this remote's shared externals
+      "@nf-internal/chunk-ABCD1234": "https://example.org/mfe1/chunk-ABCD1234.js"
     },
     "https://example.org/mfe2/": {
       "dep-c": "https://example.org/mfe1/dep-c.js"

--- a/docs/config.md
+++ b/docs/config.md
@@ -50,6 +50,7 @@ The native-federation library uses importmaps under the hood for module resolvin
 export type ImportMapOptions = {
     loadModuleFn?: (url: string) => Promise<unknown>
     setImportMapFn?: (importMap: ImportMap, opts?: { override?: boolean }) => Promise<ImportMap>
+    reloadBrowserFn?: () => void
 }
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -312,10 +312,14 @@ For example. if a mfe on page A uses the same dependency as a mfe on page B. It 
 Import map configuration determines how the browser loads JavaScript modules. This choice affects browser compatibility and loading performance.
 
 ```javascript
+import {
+  useDefaultImportMap,
+  useShimImportMap,
+} from '@softarc/native-federation-orchestrator/options';
+
+// Use native browser import maps (default)
 await initFederation(manifest, {
-  // Use native browser import maps (default)
-  importMapType: 'importmap',
-  loadModuleFn: url => import(url),
+  ...useDefaultImportMap(),
 });
 
 // OR for older browser support:
@@ -416,7 +420,7 @@ The `loadRemoteModule` function exposed by `initFederation` (also aliased as `lo
 
 ```javascript
 
-const { as, loadRemoteModule, load, remote, config } = await initFederation(manifest, {/* options */ });
+const { as, loadRemoteModule, load, initRemoteEntry, config } = await initFederation(manifest, {/* options */ });
 
 // Basic usage - loads module for side effects (e.g., custom element registration)
 await loadRemoteModule('team/button', './Button');
@@ -428,9 +432,8 @@ const buttonModule = await loadRemoteModule('team/button', './Button');
 // Type-safe usage with TypeScript
 const typedComponent = await as<ButtonComponent>().loadRemoteModule('team/button', './Button');
 
-// Remote-specific loader
-const buttonRemote = remote<ButtonComponent>('team/button');
-const button = await buttonRemote.loadModule('./Button');
+// Dynamically add a remote after initialization (see docs/version-resolver.md#dynamic-init)
+await initRemoteEntry('http://localhost:5000/remoteEntry.json', 'team/dashboard');
 
 // Reading the configuration
 console.log(config); // type: ConfigContract
@@ -471,23 +474,38 @@ initFederation(
 
 And then the `bootstrap.ts` to allow the use of the `loadRemoteModule`.
 
-```javascript
+```typescript
 import { bootstrapApplication } from '@angular/platform-browser';
 import { ApplicationConfig, InjectionToken, provideZoneChangeDetection } from '@angular/core';
 import { AppComponent } from './app/app.component';
 import { LoadRemoteModule } from '@softarc/native-federation-orchestrator';
 
-export const MODULE_LOADER = new InjectionToken() < LoadRemoteModule < unknown >> 'MODULE_LOADER';
+export const MODULE_LOADER = new InjectionToken<LoadRemoteModule>('MODULE_LOADER');
 
-const appConfig = (loader: LoadRemoteModule<unknown>): ApplicationConfig => ({
+const appConfig = (loader: LoadRemoteModule): ApplicationConfig => ({
   providers: [
     { provide: MODULE_LOADER, useValue: loader },
     provideZoneChangeDetection({ eventCoalescing: true }),
   ],
 });
 
-export const bootstrap = (loader: LoadRemoteModule<unknown>) =>
+export const bootstrap = (loader: LoadRemoteModule) =>
   bootstrapApplication(AppComponent, appConfig(loader)).catch(err => console.error(err));
+```
+
+`LoadRemoteModule` is itself a generic call signature (`<TModule = unknown>(remoteName, exposedModule) => Promise<TModule>`), so consumers pass the module type at the call site rather than on the type:
+
+```typescript
+const button = await loader<ButtonComponent>('team/button', './Button');
+```
+
+If you instead want to bind the module type to the loader variable itself, use `LoadRemoteModuleOf<TModule>`:
+
+```typescript
+import { LoadRemoteModuleOf } from '@softarc/native-federation-orchestrator';
+
+const loadButton: LoadRemoteModuleOf<ButtonComponent> = loader;
+const button = await loadButton('team/button', './Button'); // typed as ButtonComponent
 ```
 
 ## Examples

--- a/docs/version-resolver.md
+++ b/docs/version-resolver.md
@@ -16,7 +16,8 @@ Whenever a remote is bundled, Native-federation includes a metadata file called 
     ├── 📄 remoteEntry.json
     ├── 📄 button.js
     ├── 📄 dependency-a.js
-    └── 📄 dependency-b.js
+    ├── 📄 dependency-b.js
+    └── 📄 chunk-ABCD1234.js
 ```
 
 The `remoteEntry.json` contains a translation of the `federation.config.js` and serves as metadata file to explain to the orchestrator which remotes can be shared and which have to be scoped:
@@ -45,9 +46,14 @@ The `remoteEntry.json` contains a translation of the `federation.config.js` and 
       "requiredVersion": "~2.1.0",
       "singleton": true,
       "strictVersion": true,
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "bundle": "browser-dep-b"
     }
-  ]
+  ],
+  "chunks": {
+    "browser-dep-b": ["chunk-ABCD1234.js"],
+    "mapping-or-exposed": []
+  }
 }
 ```
 
@@ -57,6 +63,7 @@ These properties are very important for the orchestrator, here is what they mean
 - **singleton:** Should the orchestrator share this external with other remotes or use it only for this remote?
 - **strictVersion:** Does the remote accept versions of this external that are outside of the accepted range (requiredVersion).
 - **version:** The version of the external.
+- **bundle:** (Optional) name of the internal chunk bundle this external belongs to, resolved via the `chunks` map on the same remoteEntry. See [Shared Chunks](./architecture.md#shared-chunks) for details.
 
 ## Understanding Import Maps
 


### PR DESCRIPTION
This pull request updates the documentation to clarify and expand on how internal chunk bundling and shared externals are handled in micro frontends using `remoteEntry.json`. The main improvements include introducing the `chunks` map and `bundle` property for more precise dependency and chunk resolution, updating type signatures and examples, and providing detailed explanations of how shared chunks work during import map generation.

**Enhancements to remoteEntry.json and chunk management:**

- Added a `chunks` map to `remoteEntry.json`, mapping logical bundle names to their corresponding chunk files, enabling more efficient and accurate resolution of internal chunk dependencies. [[1]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R78-L82) [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R97) [[3]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L197-R211) [[4]](diffhunk://#diff-7d961f7de31891cf9de13787900341e9e7655ebf90651041127a7b965efa222fL48-L50)
- Introduced the `bundle` property on shared external definitions, linking each shared dependency to a specific chunk bundle for better import resolution and deduplication. [[1]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R78-L82) [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R178) [[3]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L187-R197) [[4]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R332) [[5]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R343) [[6]](diffhunk://#diff-7d961f7de31891cf9de13787900341e9e7655ebf90651041127a7b965efa222fL48-L50)

**Documentation and type updates:**

- Documented the new `chunks` map and `bundle` property, including a dedicated "Shared Chunks" section that explains how these features enable the orchestrator to resolve internal imports and avoid duplicate downloads. [[1]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R97) [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R226-R251) [[3]](diffhunk://#diff-7d961f7de31891cf9de13787900341e9e7655ebf90651041127a7b965efa222fR66)
- Updated configuration and type signatures in code examples to reflect new options and usage patterns, such as adding `reloadBrowserFn` to `ImportMapOptions` and clarifying usage of `LoadRemoteModule` generics. [[1]](diffhunk://#diff-77b3519370ff48f6caf7c316f0ece966f2f0871c40e9381d451d2c5b1c76b40fR53) [[2]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L474-R510)

**Example and usage improvements:**

- Revised and expanded code and JSON examples throughout the documentation to demonstrate the new chunk and bundle mechanics, as well as best practices for initializing and loading remotes dynamically. [[1]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L315-R322) [[2]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L419-R423) [[3]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L431-R436) [[4]](diffhunk://#diff-7d961f7de31891cf9de13787900341e9e7655ebf90651041127a7b965efa222fL19-R20)

**Import map generation:**

- Explained and illustrated how chunk files referenced by bundles are included in the final import map, ensuring that all necessary code is available for module resolution in the browser.

These changes provide a clearer, more robust foundation for managing shared dependencies and internal chunking in micro frontend architectures.