### PR TITLE
chore: Added support for trusted types

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ const HeaderComponent = await loadRemoteModule('team/mfe2', './Header');
 | [🏗️ Architecture](https://github.com/native-federation/orchestrator/blob/main/docs/architecture.md)           | Understanding the native federation domain |
 | [⚙️ Configuration](https://github.com/native-federation/orchestrator/blob/main/docs/config.md)                | Complete configuration reference           |
 | [🔄 Version Resolution](https://github.com/native-federation/orchestrator/blob/main/docs/version-resolver.md) | How dependency conflicts are resolved      |
+| [🔒 Security & Trusted Types](https://github.com/native-federation/orchestrator/blob/main/docs/security.md)   | CSP setup and the built-in Trusted Types policy |
 
 ## Example repositories
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,6 +161,7 @@ classDiagram
         exposes: ExposesInfo[]
         shared: SharedInfo[]
         chunks?: Map<.string, string[]>
+        integrity?: Map<.string, string>
     }
     class ExposesInfo{
         key: string
@@ -208,9 +209,17 @@ classDiagram
   "chunks": {
     "browser-dep-a": ["chunk-ABCD1234.js"],
     "mapping-or-exposed": []
+  },
+  "integrity": {
+    "component-a.js": "sha384-…",
+    "dep-a.js": "sha384-…",
+    "dep-b.js": "sha384-…",
+    "chunk-ABCD1234.js": "sha384-…"
   }
 }
 ```
+
+The optional `integrity` map (added by `@softarc/native-federation` when built with `integrity: true`) carries an SRI hash per emitted file, keyed by `outFileName`. The orchestrator resolves these to absolute URLs and emits them under the `integrity` block of the generated import map. See [Security — Subresource Integrity](./security.md#subresource-integrity) for the end-to-end trust chain.
 
 #### Shared External Properties
 
@@ -269,6 +278,7 @@ classDiagram
     class RemoteInfo {
         scopeUrl: string
         exposes: RemoteModule[]
+        integrity?: Map<.string, string>
     }
 
     class RemoteModule{
@@ -466,6 +476,11 @@ The final import map provides the browser with optimized module resolution instr
     "https://example.org/mfe2/": {
       "dep-c": "https://example.org/mfe1/dep-c.js"
     }
+  },
+  "integrity": {
+    // Only present for URLs whose remoteEntry.json published a hash
+    "https://ecommerce-team.com/cart-button.js": "sha384-…",
+    "https://example.org/mfe1/dep-a.js":         "sha384-…"
   }
 }
 ```
@@ -476,6 +491,7 @@ This structure enables:
 - **Scoped isolation** via the scopes object (dep-b only loads for its specific micro frontend)
 - **Grouped externals** Reusing compatible externals with the same `shareScope` to minimize downloads even more!
 - **Optimal caching** through strategic version selection and reuse
+- **Tamper-evident loads** via the optional `integrity` block — see [Security — Subresource Integrity](./security.md#subresource-integrity)
 
 ## Caching and Performance
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -51,16 +51,18 @@ export type ImportMapOptions = {
     loadModuleFn?: (url: string) => Promise<unknown>
     setImportMapFn?: (importMap: ImportMap, opts?: { override?: boolean }) => Promise<ImportMap>
     reloadBrowserFn?: () => void
+    trustedTypesPolicyName?: string | false
 }
 ```
 
 ### Options:
 
-| Option          | Default                             | Description                                                                                                                        |
-| --------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| setImportMapFn  | `replaceInDOM("importmap")`         | The function that adds the importmap to the host, by default this is the DOM.                                                      |
-| loadModuleFn    | `url => import(url)`                | This function can mock or alter the 'import' function, necessary for libraries that shim the import function.                      |
-| reloadBrowserFn | `() => {window.location.reload();}` | This function can mock or alter the "reload browser" behavior that is triggered when SSE is enabled and an user rebuilds a remote. |
+| Option                 | Default                             | Description                                                                                                                                                                                                                                |
+| ---------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| setImportMapFn         | `replaceInDOM("importmap")`         | The function that adds the importmap to the host, by default this is the DOM.                                                                                                                                                              |
+| loadModuleFn           | `url => import(url)`                | This function can mock or alter the 'import' function, necessary for libraries that shim the import function.                                                                                                                              |
+| reloadBrowserFn        | `() => {window.location.reload();}` | This function can mock or alter the "reload browser" behavior that is triggered when SSE is enabled and an user rebuilds a remote.                                                                                                         |
+| trustedTypesPolicyName | `"nfo"`                             | Name of the [Trusted Types](./security.md) policy that wraps import-map content and dynamic-import URLs in the default `setImportMapFn` and `loadModuleFn`. Pass `false` to opt out. No effect on browsers that do not support Trusted Types. |
 
 ### Example
 
@@ -79,8 +81,13 @@ initFederation('http://example.org/manifest.json', {
   // Option 3: Custom properties
   loadModuleFn: (url: string) => { return customImport(url); },
   setImportMapFn: replaceInDOM('<importmap-type>'),
+
+  // Option 4: rename the Trusted Types policy to match a stricter CSP allowlist
+  trustedTypesPolicyName: 'my-app-nfo',
 });
 ```
+
+> See [Security & Trusted Types](./security.md) for the recommended CSP header and how the orchestrator interacts with a host-defined policy.
 
 ## <a id="loggingConfig"></a> 3. Logging configuration
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,16 +21,19 @@ export type HostOptions = {
     hostRemoteEntry?: string | false | {
         name?: string,
         url: string,
-        cacheTag?: string
-    }
+        cacheTag?: string,
+        integrity?: string
+    },
+    manifestIntegrity?: string
 }
 ```
 
 ### Options:
 
-| Option          | Default | Description                                               |
-| --------------- | ------- | --------------------------------------------------------- |
-| hostRemoteEntry | `false` | Allows for the inclusion of a host remoteEntry.json file. |
+| Option            | Default     | Description                                                                                                                                                                              |
+| ----------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| hostRemoteEntry   | `false`     | Allows for the inclusion of a host remoteEntry.json file. The optional `integrity` field pins the host's remoteEntry.json against an SRI hash (see [Security](./security.md#subresource-integrity)). |
+| manifestIntegrity | `undefined` | SRI hash for the manifest URL passed as the first argument to `initFederation`. When set, the orchestrator verifies the manifest bytes before parsing.                                   |
 
 ### Example
 
@@ -41,6 +44,34 @@ initFederation('http://example.org/manifest.json', {
   hostRemoteEntry: { url: './remoteEntry.json' },
 });
 ```
+
+### Pinning resources with integrity
+
+Manifest entries, the manifest URL itself, and the host remoteEntry can each carry an SRI hash. Verification is opt-in per resource — entries without a hash are fetched unverified, matching the semantics of `<script integrity="…">`.
+
+```javascript
+initFederation('http://example.org/manifest.json', {
+  manifestIntegrity: 'sha384-…',
+  hostRemoteEntry: {
+    url: './host-remoteEntry.json',
+    integrity: 'sha384-…',
+  },
+});
+```
+
+Per-remote pinning lives in the manifest itself — entries can be either the existing string form or a `{ url, integrity }` object:
+
+```json
+{
+  "team/mfe1": "https://mfe1.example.org/remoteEntry.json",
+  "team/mfe2": {
+    "url": "https://mfe2.example.org/remoteEntry.json",
+    "integrity": "sha384-…"
+  }
+}
+```
+
+> See [Security & Subresource Integrity](./security.md#subresource-integrity) for the full trust chain (manifest → remoteEntry.json → modules) and the supported hash algorithms.
 
 ## <a id="importMapConfig"></a> 2. ImportMap configuration
 
@@ -87,7 +118,7 @@ initFederation('http://example.org/manifest.json', {
 });
 ```
 
-> See [Security & Trusted Types](./security.md) for the recommended CSP header and how the orchestrator interacts with a host-defined policy.
+> See [Security — Trusted Types](./security.md#trusted-types) for the recommended CSP header and how the orchestrator interacts with a host-defined policy.
 
 ## <a id="loggingConfig"></a> 3. Logging configuration
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,6 +78,20 @@ Each entry maps a logical name (like "@team/component") to the URL of that micro
 
 > 🧠 In production environments it would make more sense to fetch the manifest from some sort of micro frontend discovery service or feed.
 
+Manifest entries can also be supplied as objects to pin a remoteEntry.json against an SRI hash (the orchestrator verifies the bytes before parsing). Both forms can coexist:
+
+```json
+{
+  "team/mfe1": "http://localhost:3000/remoteEntry.json",
+  "team/mfe2": {
+    "url": "http://localhost:4000/remoteEntry.json",
+    "integrity": "sha384-…"
+  }
+}
+```
+
+> See [Security — Subresource Integrity](./security.md#subresource-integrity) for the full picture, including pinning the manifest URL itself and propagating module hashes into the import map.
+
 **Event Handler Setup**<br />
 The micro frontend loading process is asynchronous - the runtime needs time to fetch metadata, resolve dependencies, and set up import maps. The `mfe-loader-available` event signals when this process is complete and the `loadRemoteModule` function is ready to use.
 
@@ -434,6 +448,12 @@ const typedComponent = await as<ButtonComponent>().loadRemoteModule('team/button
 
 // Dynamically add a remote after initialization (see docs/version-resolver.md#dynamic-init)
 await initRemoteEntry('http://localhost:5000/remoteEntry.json', 'team/dashboard');
+
+// initRemoteEntry can also pin the remoteEntry.json against an SRI hash
+await initRemoteEntry('http://localhost:5000/remoteEntry.json', {
+  name: 'team/dashboard',
+  integrity: 'sha384-…',
+});
 
 // Reading the configuration
 console.log(config); // type: ConfigContract

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,12 +1,19 @@
 [< back](./../README.md)
 
-# Security & Trusted Types
+# Security
+
+The orchestrator ships two complementary security features:
+
+1. [**Trusted Types**](#trusted-types) — wraps the orchestrator's two DOM sinks (the injected `<script type="importmap">` and the dynamic `import()` call) in a vetted policy so raw strings never reach a script-execution sink.
+2. [**Subresource Integrity (SRI)**](#subresource-integrity) — verifies the bytes of the manifest, every `remoteEntry.json`, and every JavaScript module the import map points at against the SHA hashes published by the build.
+
+The two features layer cleanly: Trusted Types makes sinks structurally safe, while SRI makes the data flowing through them tamper-evident.
+
+## <a id="trusted-types"></a> Trusted Types
 
 The orchestrator is compatible with the browser [Trusted Types](https://www.w3.org/TR/trusted-types/) API. When the host application enables Trusted Types via Content Security Policy, the orchestrator's two DOM sinks — the `<script type="importmap">` it injects and the dynamic `import()` it uses to load remote modules — flow through a vetted policy instead of writing raw strings.
 
-This page covers what the orchestrator does, the recommended CSP, and how to integrate with a host that already manages its own policies.
-
-## What the orchestrator protects
+### What the orchestrator protects
 
 The library has two places where externally-fetched data reaches a script-execution sink:
 
@@ -22,7 +29,7 @@ Both go through a single Trusted Types policy named `nfo` by default. The policy
 
 On browsers without Trusted Types (and in test environments such as jsdom) the wrapper is a transparent pass-through, so the library behaves identically to a non-Trusted-Types build.
 
-## Recommended CSP
+### Recommended CSP
 
 For a host that wants Trusted Types enforced and uses the orchestrator's defaults:
 
@@ -36,7 +43,7 @@ If the host registers its own policies in addition to `nfo`, list them all (and 
 Content-Security-Policy: require-trusted-types-for 'script'; trusted-types nfo my-host-policy 'allow-duplicates'
 ```
 
-### Phased rollout
+#### Phased rollout
 
 Trusted Types is best deployed in stages. Start in report-only mode to surface every violation without breaking the page:
 
@@ -46,7 +53,7 @@ Content-Security-Policy-Report-Only: require-trusted-types-for 'script'; trusted
 
 Once the report stream is empty, switch to the enforcing header above.
 
-## Configuration
+### Configuration
 
 The Trusted Types policy is part of the [import-map configuration](./config.md#importMapConfig) and exposes a single option, `trustedTypesPolicyName`.
 
@@ -59,7 +66,7 @@ initFederation('http://example.org/manifest.json', {
 });
 ```
 
-### Renaming the policy
+#### Renaming the policy
 
 If your CSP `trusted-types` allowlist uses different names (for example to keep a project-wide naming convention), rename the orchestrator's policy:
 
@@ -73,7 +80,7 @@ initFederation('http://example.org/manifest.json', {
 Content-Security-Policy: require-trusted-types-for 'script'; trusted-types my-app-nfo
 ```
 
-### Opting out
+#### Opting out
 
 Set the option to `false` when the host already wraps the import map and module URLs through its own policy (for example by overriding `setImportMapFn` and `loadModuleFn`):
 
@@ -87,9 +94,136 @@ initFederation('http://example.org/manifest.json', {
 
 With `trustedTypesPolicyName: false` the orchestrator will not call `trustedTypes.createPolicy` at all — useful when the CSP allowlist does not include `nfo` or when a `default` policy is already in place site-wide.
 
-## Caveats
+### Caveats
 
 - **Default policy.** The orchestrator does not register a `default` policy. If your host uses one, the host's `default` policy is also consulted whenever a raw string reaches a sink — make sure it is compatible with the import-map and remote-URL data the orchestrator produces, or override the relevant functions.
 - **Custom `setImportMapFn` / `loadModuleFn`.** The Trusted Types policy is only active inside the orchestrator's *default* implementations. When you supply your own functions you are responsible for producing trusted values yourself; setting `trustedTypesPolicyName: false` documents that intent.
 - **Browser support.** Trusted Types is part of the 2026 Baseline (Chromium 83+, WebKit 26+, Gecko 148+). On older browsers the orchestrator's policy wrapper is a no-op, so existing deployments keep working without modification.
 - **Policy ≠ sanitizer.** Trusted Types makes sinks structurally safe by funnelling all writes through a single, auditable choke point. The validators shipped with the orchestrator only check shape (JSON structure, URL protocol) — they are not a substitute for end-to-end controls on which manifests and remote origins your host trusts in the first place.
+
+## <a id="subresource-integrity"></a> Subresource Integrity
+
+The orchestrator can verify the bytes of every artifact it touches against an SRI-style hash before they are used. Verification is **opt-in per resource**: provide a hash and the bytes are checked, omit the hash and the resource is fetched as-is. This mirrors how the browser's `<script integrity="…">` attribute works.
+
+### What can be pinned
+
+| Resource | Where the hash lives | Verified by |
+| --- | --- | --- |
+| `manifest.json` | `manifestIntegrity` option on `initFederation` | Manifest provider hashes the response bytes before parsing |
+| Each `remoteEntry.json` | `integrity` field on the manifest entry, or `hostRemoteEntry.integrity` | Remote-entry provider hashes the response bytes before parsing |
+| Every shared external, exposed module, and chunk file | `integrity` map on `remoteEntry.json` (emitted by `@softarc/native-federation` when the build uses `integrity: true`) | Browser / `es-module-shims` honors the `integrity` block of the generated import map |
+
+These three layers form a trust chain: pinning the manifest pins which `remoteEntry.json` files are trusted, each of which pins the modules the page actually executes.
+
+### Module & chunk integrity (import map)
+
+When `@softarc/native-federation` is built with `integrity: true`, the generated `remoteEntry.json` carries a top-level `integrity` map keyed by `outFileName`:
+
+```json
+{
+  "name": "team/mfe1",
+  "exposes": [{ "key": "./Button", "outFileName": "button.js" }],
+  "shared": [
+    { "packageName": "react", "outFileName": "react.js", "version": "18.2.0", … }
+  ],
+  "chunks": { "browser-react": ["chunk-ABCD1234.js"] },
+  "integrity": {
+    "button.js": "sha384-…",
+    "react.js": "sha384-…",
+    "chunk-ABCD1234.js": "sha384-…"
+  }
+}
+```
+
+The orchestrator copies these hashes onto every URL it emits and writes the result into the `integrity` block of the import map it injects into the DOM:
+
+```html
+<script type="importmap">
+{
+  "imports": {
+    "team/mfe1/./Button": "https://mfe1.example.org/button.js",
+    "react":              "https://mfe1.example.org/react.js"
+  },
+  "scopes": {
+    "https://mfe1.example.org/": {
+      "@nf-internal/chunk-ABCD1234": "https://mfe1.example.org/chunk-ABCD1234.js"
+    }
+  },
+  "integrity": {
+    "https://mfe1.example.org/button.js":            "sha384-…",
+    "https://mfe1.example.org/react.js":             "sha384-…",
+    "https://mfe1.example.org/chunk-ABCD1234.js":    "sha384-…"
+  }
+}
+</script>
+```
+
+URLs without a hash are simply omitted from the `integrity` block (matching the SRI spec).
+
+**Enforcement** depends on the import-map runtime:
+
+- With `useShimImportMap()` ([es-module-shims](https://www.npmjs.com/package/es-module-shims)) the `integrity` block is fully enforced today — modules with a mismatched hash fail to load.
+- With `useDefaultImportMap()` (native browser `import()`) the `integrity` block is honored when the [import-map integrity proposal](https://github.com/WICG/import-maps/issues/174) ships in the user's browser. On older browsers it is silently ignored, so the import map remains backwards-compatible.
+
+### Pinning `remoteEntry.json` and `manifest.json`
+
+`remoteEntry.json` and `manifest.json` are fetched as JSON, not as scripts, so SRI's `<script integrity>` attribute does not apply. The orchestrator instead computes a SHA-256 / SHA-384 / SHA-512 digest of the response bytes itself (`crypto.subtle.digest`) and compares it to the hash you provide. A mismatch rejects with an `NFError`.
+
+#### Per-remote integrity in the manifest
+
+A manifest entry can be either the existing string form or a `{ url, integrity }` object — they coexist freely:
+
+```json
+{
+  "team/mfe1": "https://mfe1.example.org/remoteEntry.json",
+  "team/mfe2": {
+    "url": "https://mfe2.example.org/remoteEntry.json",
+    "integrity": "sha384-…"
+  }
+}
+```
+
+#### Manifest URL integrity
+
+When the orchestrator fetches the manifest itself from a URL, pass `manifestIntegrity` to verify it:
+
+```javascript
+import { initFederation } from '@softarc/native-federation-orchestrator';
+
+initFederation('http://example.org/manifest.json', {
+  manifestIntegrity: 'sha384-…',
+});
+```
+
+#### Host remote-entry integrity
+
+The host's own `remoteEntry.json` is configured separately and supports the same `integrity` field:
+
+```javascript
+initFederation(manifest, {
+  hostRemoteEntry: {
+    url: './host-remoteEntry.json',
+    integrity: 'sha384-…',
+  },
+});
+```
+
+#### Dynamically added remotes
+
+`initRemoteEntry` accepts the same `RemoteRef` shape, so a dynamically added remote can also be pinned:
+
+```javascript
+const { initRemoteEntry } = await initFederation(manifest, { /* … */ });
+
+await initRemoteEntry('http://example.org/late-mfe/remoteEntry.json', {
+  name: 'team/late-mfe',
+  integrity: 'sha384-…',
+});
+```
+
+### Caveats
+
+- **Opt-in semantics.** Resources without a configured hash are *not* verified. There is no global "strict integrity" switch — if you want every fetch to be pinned, configure a hash on every entry.
+- **Supported algorithms.** `sha256-`, `sha384-`, and `sha512-` are accepted, matching the SRI spec. The build-side default (`@softarc/native-federation`) is `sha384-`.
+- **Trust root.** Module hashes only protect the page if the `remoteEntry.json` that publishes them is itself trusted. Pin the manifest (or the host's own remoteEntry) at the top so an attacker who tampers with `remoteEntry.json` cannot also rewrite the hashes inside it.
+- **JSON bytes, not the parsed value.** The manifest and remote-entry hashes are computed over the exact response bytes. Re-serialising the JSON (whitespace, key order) at the origin will invalidate the hash — pin the file you publish, not a regenerated copy.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,95 @@
+[< back](./../README.md)
+
+# Security & Trusted Types
+
+The orchestrator is compatible with the browser [Trusted Types](https://www.w3.org/TR/trusted-types/) API. When the host application enables Trusted Types via Content Security Policy, the orchestrator's two DOM sinks — the `<script type="importmap">` it injects and the dynamic `import()` it uses to load remote modules — flow through a vetted policy instead of writing raw strings.
+
+This page covers what the orchestrator does, the recommended CSP, and how to integrate with a host that already manages its own policies.
+
+## What the orchestrator protects
+
+The library has two places where externally-fetched data reaches a script-execution sink:
+
+| Sink                                          | Source of the data                            | Trusted type      |
+| --------------------------------------------- | --------------------------------------------- | ----------------- |
+| `<script type="importmap">` content (`replaceInDOM`) | Resolved import map built from `remoteEntry.json` files | `TrustedScript`   |
+| Dynamic `import(url)` (`loadModuleFn`)        | Module URLs declared by remotes               | `TrustedScriptURL` |
+
+Both go through a single Trusted Types policy named `nfo` by default. The policy applies two checks:
+
+- **`createScript`** — re-parses the input and verifies it is a valid import map (a plain object with only `imports`, `scopes`, or `integrity` keys). Rejects anything else with a `TypeError`.
+- **`createScriptURL`** — verifies the input parses as a URL with an `http:` or `https:` protocol. Rejects `javascript:`, `data:`, and malformed URLs.
+
+On browsers without Trusted Types (and in test environments such as jsdom) the wrapper is a transparent pass-through, so the library behaves identically to a non-Trusted-Types build.
+
+## Recommended CSP
+
+For a host that wants Trusted Types enforced and uses the orchestrator's defaults:
+
+```
+Content-Security-Policy: require-trusted-types-for 'script'; trusted-types nfo
+```
+
+If the host registers its own policies in addition to `nfo`, list them all (and add `'allow-duplicates'` if a name is registered more than once):
+
+```
+Content-Security-Policy: require-trusted-types-for 'script'; trusted-types nfo my-host-policy 'allow-duplicates'
+```
+
+### Phased rollout
+
+Trusted Types is best deployed in stages. Start in report-only mode to surface every violation without breaking the page:
+
+```
+Content-Security-Policy-Report-Only: require-trusted-types-for 'script'; trusted-types nfo; report-uri /csp-reports
+```
+
+Once the report stream is empty, switch to the enforcing header above.
+
+## Configuration
+
+The Trusted Types policy is part of the [import-map configuration](./config.md#importMapConfig) and exposes a single option, `trustedTypesPolicyName`.
+
+```javascript
+import { initFederation } from '@softarc/native-federation-orchestrator';
+
+initFederation('http://example.org/manifest.json', {
+  // default
+  trustedTypesPolicyName: 'nfo',
+});
+```
+
+### Renaming the policy
+
+If your CSP `trusted-types` allowlist uses different names (for example to keep a project-wide naming convention), rename the orchestrator's policy:
+
+```javascript
+initFederation('http://example.org/manifest.json', {
+  trustedTypesPolicyName: 'my-app-nfo',
+});
+```
+
+```
+Content-Security-Policy: require-trusted-types-for 'script'; trusted-types my-app-nfo
+```
+
+### Opting out
+
+Set the option to `false` when the host already wraps the import map and module URLs through its own policy (for example by overriding `setImportMapFn` and `loadModuleFn`):
+
+```javascript
+initFederation('http://example.org/manifest.json', {
+  trustedTypesPolicyName: false,
+  setImportMapFn: myHostsTrustedSetImportMap,
+  loadModuleFn: myHostsTrustedImport,
+});
+```
+
+With `trustedTypesPolicyName: false` the orchestrator will not call `trustedTypes.createPolicy` at all — useful when the CSP allowlist does not include `nfo` or when a `default` policy is already in place site-wide.
+
+## Caveats
+
+- **Default policy.** The orchestrator does not register a `default` policy. If your host uses one, the host's `default` policy is also consulted whenever a raw string reaches a sink — make sure it is compatible with the import-map and remote-URL data the orchestrator produces, or override the relevant functions.
+- **Custom `setImportMapFn` / `loadModuleFn`.** The Trusted Types policy is only active inside the orchestrator's *default* implementations. When you supply your own functions you are responsible for producing trusted values yourself; setting `trustedTypesPolicyName: false` documents that intent.
+- **Browser support.** Trusted Types is part of the 2026 Baseline (Chromium 83+, WebKit 26+, Gecko 148+). On older browsers the orchestrator's policy wrapper is a no-op, so existing deployments keep working without modification.
+- **Policy ≠ sanitizer.** Trusted Types makes sinks structurally safe by funnelling all writes through a single, auditable choke point. The validators shipped with the orchestrator only check shape (JSON structure, URL protocol) — they are not a substitute for end-to-end controls on which manifests and remote origins your host trusts in the first place.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.2",
+  "version": "4.1.0",
   "name": "@softarc/native-federation-orchestrator",
   "author": "Aukevanoost",
   "keywords": [
@@ -27,7 +27,7 @@
     "@babel/core": "^7.29.0",
     "@babel/preset-env": "^7.29.0",
     "@babel/preset-typescript": "^7.28.5",
-    "@softarc/native-federation": "^4.0.0",
+    "@softarc/native-federation": "^4.1.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.1",
     "@types/semver": "^7.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,13 +20,13 @@ importers:
         version: 7.29.0
       '@babel/preset-env':
         specifier: ^7.29.0
-        version: 7.29.2(@babel/core@7.29.0)
+        version: 7.29.3(@babel/core@7.29.0)
       '@babel/preset-typescript':
         specifier: ^7.28.5
         version: 7.28.5(@babel/core@7.29.0)
       '@softarc/native-federation':
-        specifier: ^4.0.0
-        version: 4.0.0(typescript@5.9.3)
+        specifier: ^4.1.0
+        version: 4.1.0(typescript@5.9.3)
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -38,10 +38,10 @@ importers:
         version: 7.7.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.30.1
-        version: 8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+        version: 8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.30.1
-        version: 8.59.0(eslint@9.39.4)(typescript@5.9.3)
+        version: 8.59.1(eslint@9.39.4)(typescript@5.9.3)
       babel-jest:
         specifier: ^30.2.0
         version: 30.3.0(@babel/core@7.29.0)
@@ -88,8 +88,8 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.29.0':
-    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.29.0':
@@ -108,8 +108,8 @@ packages:
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-create-class-features-plugin@7.28.6':
-    resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
+  '@babel/helper-create-class-features-plugin@7.29.3':
+    resolution: {integrity: sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -187,8 +187,8 @@ packages:
     resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -206,6 +206,12 @@ packages:
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1':
     resolution: {integrity: sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3':
+    resolution: {integrity: sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -643,8 +649,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/preset-env@7.29.2':
-    resolution: {integrity: sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==}
+  '@babel/preset-env@7.29.3':
+    resolution: {integrity: sha512-ySZypNLAIH1ClygLDQzVMoGQRViATnkHkYYV6TcNDz+8+jwZCdsguGvsb3EY5d9wyWyhmF1iSuFM0Yh5XPnqSA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1234,8 +1240,8 @@ packages:
   '@sinonjs/fake-timers@15.3.2':
     resolution: {integrity: sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==}
 
-  '@softarc/native-federation@4.0.0':
-    resolution: {integrity: sha512-O0IQwdeVxIRTz0VsjinUHJt/NrxXseys6yTHtybkolbdDGGUJxuaCvwDRFUuMJmV3lsd8UDZIBloN69uhZNxug==}
+  '@softarc/native-federation@4.1.0':
+    resolution: {integrity: sha512-8/gP/MlERF2G3yKPl1UvWg3xioIffYJavG1TCX18rW+Qs809uJMGcoDsCFQB4dXbLDJBVIbwxpmIPFvshO1aeQ==}
 
   '@softarc/sheriff-core@0.19.6':
     resolution: {integrity: sha512-KACxHG9sS7kNWgnnBODzdr14kMLMrJVlQKc+tViUP03p2fRwNhESOA49bz51Yn7dro1mbtMmmFjICLmZSJDZZA==}
@@ -1297,63 +1303,63 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@typescript-eslint/eslint-plugin@8.59.0':
-    resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
+  '@typescript-eslint/eslint-plugin@8.59.1':
+    resolution: {integrity: sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.59.0
+      '@typescript-eslint/parser': ^8.59.1
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.59.0':
-    resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.59.0':
-    resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.59.0':
-    resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.59.0':
-    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.59.0':
-    resolution: {integrity: sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==}
+  '@typescript-eslint/parser@8.59.1':
+    resolution: {integrity: sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.59.0':
-    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.59.0':
-    resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
+  '@typescript-eslint/project-service@8.59.1':
+    resolution: {integrity: sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.59.0':
-    resolution: {integrity: sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==}
+  '@typescript-eslint/scope-manager@8.59.1':
+    resolution: {integrity: sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.1':
+    resolution: {integrity: sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.59.1':
+    resolution: {integrity: sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.59.0':
-    resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
+  '@typescript-eslint/types@8.59.1':
+    resolution: {integrity: sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.1':
+    resolution: {integrity: sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.1':
+    resolution: {integrity: sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.1':
+    resolution: {integrity: sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -1479,8 +1485,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ajv@6.14.0:
-    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -1572,8 +1578,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.20:
-    resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
+  baseline-browser-mapping@2.10.25:
+    resolution: {integrity: sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1630,8 +1636,8 @@ packages:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
 
-  caniuse-lite@1.0.30001788:
-    resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
   chalk-template@0.4.0:
     resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
@@ -1765,8 +1771,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.341:
-    resolution: {integrity: sha512-1sZTssferjgDgaqRTc0ieP+ozzpOy7LQTPTtEW3yQFn4+ORdIAZWV5BthXPyHF7YqLvFJCUPhNhdAJQYlYUgiw==}
+  electron-to-chromium@1.5.349:
+    resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -2446,8 +2452,8 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
-  node-releases@2.0.37:
-    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -2981,7 +2987,7 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.0': {}
+  '@babel/compat-data@7.29.3': {}
 
   '@babel/core@7.29.0':
     dependencies:
@@ -2990,7 +2996,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -3005,7 +3011,7 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -3017,13 +3023,13 @@ snapshots:
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.3
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
@@ -3129,7 +3135,7 @@ snapshots:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
 
-  '@babel/parser@7.29.2':
+  '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
 
@@ -3150,6 +3156,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
     dependencies:
@@ -3304,7 +3318,7 @@ snapshots:
   '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -3312,7 +3326,7 @@ snapshots:
   '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -3515,7 +3529,7 @@ snapshots:
   '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -3524,7 +3538,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -3582,7 +3596,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
@@ -3612,9 +3626,9 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.2(@babel/core@7.29.0)':
+  '@babel/preset-env@7.29.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.3
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
@@ -3622,6 +3636,7 @@ snapshots:
       '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
       '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.3(@babel/core@7.29.0)
       '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
@@ -3709,7 +3724,7 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
   '@babel/traverse@7.29.0':
@@ -3717,7 +3732,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       debug: 4.4.3
@@ -3948,7 +3963,7 @@ snapshots:
 
   '@eslint/eslintrc@3.3.5':
     dependencies:
-      ajv: 6.14.0
+      ajv: 6.15.0
       debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
@@ -4245,7 +4260,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@softarc/native-federation@4.0.0(typescript@5.9.3)':
+  '@softarc/native-federation@4.1.0(typescript@5.9.3)':
     dependencies:
       '@softarc/sheriff-core': 0.19.6(typescript@5.9.3)
       chalk: 5.6.2
@@ -4266,7 +4281,7 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
@@ -4278,7 +4293,7 @@ snapshots:
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
   '@types/babel__traverse@7.28.0':
@@ -4326,14 +4341,14 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/type-utils': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.59.0
+      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.1
+      '@typescript-eslint/type-utils': 8.59.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.1
       eslint: 9.39.4
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -4342,41 +4357,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.1(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.59.0
+      '@typescript-eslint/scope-manager': 8.59.1
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3
       eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.59.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.1
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.59.0':
+  '@typescript-eslint/scope-manager@8.59.1':
     dependencies:
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/visitor-keys': 8.59.0
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/visitor-keys': 8.59.1
 
-  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.1(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.59.0(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.1(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4)(typescript@5.9.3)
       debug: 4.4.3
       eslint: 9.39.4
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -4384,14 +4399,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.59.0': {}
+  '@typescript-eslint/types@8.59.1': {}
 
-  '@typescript-eslint/typescript-estree@8.59.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.59.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/visitor-keys': 8.59.0
+      '@typescript-eslint/project-service': 8.59.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
@@ -4401,20 +4416,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.0(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.1(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
-      '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.1
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
       eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.59.0':
+  '@typescript-eslint/visitor-keys@8.59.1':
     dependencies:
-      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/types': 8.59.1
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
@@ -4488,7 +4503,7 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv@6.14.0:
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -4562,7 +4577,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.3
       '@babel/core': 7.29.0
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       semver: 6.3.1
@@ -4613,13 +4628,13 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.20: {}
+  baseline-browser-mapping@2.10.25: {}
 
   boxen@7.0.0:
     dependencies:
       ansi-align: 3.0.1
       camelcase: 7.0.1
-      chalk: 5.6.2
+      chalk: 5.0.1
       cli-boxes: 3.0.0
       string-width: 5.1.2
       type-fest: 2.19.0
@@ -4645,10 +4660,10 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.20
-      caniuse-lite: 1.0.30001788
-      electron-to-chromium: 1.5.341
-      node-releases: 2.0.37
+      baseline-browser-mapping: 2.10.25
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.349
+      node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   bser@2.1.1:
@@ -4669,7 +4684,7 @@ snapshots:
 
   camelcase@7.0.1: {}
 
-  caniuse-lite@1.0.30001788: {}
+  caniuse-lite@1.0.30001791: {}
 
   chalk-template@0.4.0:
     dependencies:
@@ -4778,7 +4793,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.341: {}
+  electron-to-chromium@1.5.349: {}
 
   emittery@0.13.1: {}
 
@@ -4912,7 +4927,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.14.0
+      ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -5185,7 +5200,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.4
@@ -5670,7 +5685,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-releases@2.0.37: {}
+  node-releases@2.0.38: {}
 
   normalize-path@3.0.0: {}
 

--- a/src/lib/1.domain/import-map/import-map.contract.ts
+++ b/src/lib/1.domain/import-map/import-map.contract.ts
@@ -2,9 +2,12 @@ type Imports = Record<string, string>;
 
 type Scopes = Record<string, Imports>;
 
+type Integrity = Record<string, string>;
+
 type ImportMap = {
   imports: Imports;
   scopes?: Scopes;
+  integrity?: Integrity;
 };
 
-export { Scopes, Imports, ImportMap };
+export { Scopes, Imports, Integrity, ImportMap };

--- a/src/lib/1.domain/remote-entry/manifest.contract.ts
+++ b/src/lib/1.domain/remote-entry/manifest.contract.ts
@@ -2,4 +2,6 @@ import type { RemoteName } from '../remote/remote-info.contract';
 
 export type RemoteEntryUrl = string;
 
-export type Manifest = Record<RemoteName, RemoteEntryUrl>;
+export type RemoteEntryDescriptor = RemoteEntryUrl | { url: RemoteEntryUrl; integrity?: string };
+
+export type Manifest = Record<RemoteName, RemoteEntryDescriptor>;

--- a/src/lib/1.domain/remote/remote-info.contract.ts
+++ b/src/lib/1.domain/remote/remote-info.contract.ts
@@ -4,9 +4,12 @@ export type RemoteName = string;
 
 export type RemoteScope = string;
 
+export type RemoteIntegrity = Record<string, string>;
+
 export type RemoteInfo = {
   scopeUrl: RemoteScope;
   exposes: RemoteModule[];
+  integrity?: RemoteIntegrity;
 };
 
 export type Remotes = Record<string, RemoteInfo>;

--- a/src/lib/2.app/config/host.contract.ts
+++ b/src/lib/2.app/config/host.contract.ts
@@ -5,7 +5,9 @@ export type HostConfig = {
         name: string;
         url: string;
         cacheTag?: string;
+        integrity?: string;
       };
+  manifestIntegrity?: string;
 };
 
 export type HostOptions = {
@@ -16,5 +18,7 @@ export type HostOptions = {
         name?: string;
         url: string;
         cacheTag?: string;
+        integrity?: string;
       };
+  manifestIntegrity?: string;
 };

--- a/src/lib/2.app/config/import-map.contract.ts
+++ b/src/lib/2.app/config/import-map.contract.ts
@@ -11,4 +11,15 @@ export type SetImportMap = (
   opts?: { override?: boolean }
 ) => Promise<ImportMap>;
 
-export type ImportMapOptions = Partial<ImportMapConfig>;
+export type ImportMapOptions = Partial<ImportMapConfig> & {
+  /**
+   * Name of the Trusted Types policy used to wrap import-map content and
+   * dynamic-import URLs in the default `setImportMapFn` and `loadModuleFn`.
+   * Pass `false` to disable the policy (e.g. when the host owns its own
+   * Trusted Types pipeline). Defaults to `'nfo'`.
+   *
+   * Has no effect on browsers that do not support Trusted Types — the wrapper
+   * falls back to a transparent pass-through in that case.
+   */
+  trustedTypesPolicyName?: string | false;
+};

--- a/src/lib/2.app/driver-ports/dynamic-init/flow.contract.ts
+++ b/src/lib/2.app/driver-ports/dynamic-init/flow.contract.ts
@@ -1,11 +1,13 @@
+export type RemoteRef = string | { name?: string; integrity?: string };
+
 export type DynamicInitResult<TFederationResult = {}> = TFederationResult & {
   initRemoteEntry: (
     remoteEntryUrl: string,
-    remoteName?: string
+    remote?: RemoteRef
   ) => Promise<DynamicInitResult<TFederationResult>>;
 };
 
 export type DynamicInitFlow = (
   remoteEntryUrl: string,
-  remoteName?: string
+  remote?: RemoteRef
 ) => Promise<DynamicInitResult>;

--- a/src/lib/2.app/driver-ports/dynamic-init/for-getting-remote-entry.port.ts
+++ b/src/lib/2.app/driver-ports/dynamic-init/for-getting-remote-entry.port.ts
@@ -1,7 +1,8 @@
 import type { RemoteEntry } from 'lib/1.domain/remote-entry/remote-entry.contract';
 import type { Optional } from 'lib/utils/optional';
+import type { RemoteRef } from './flow.contract';
 
 export type ForGettingRemoteEntry = (
   remoteEntryUrl: string,
-  remoteName?: string
+  remote?: RemoteRef
 ) => Promise<Optional<RemoteEntry>>;

--- a/src/lib/2.app/driving-ports/for-providing-manifest.port.ts
+++ b/src/lib/2.app/driving-ports/for-providing-manifest.port.ts
@@ -1,5 +1,8 @@
 import type { Manifest } from 'lib/1.domain/remote-entry/manifest.contract';
 
 export type ForProvidingManifest = {
-  provide: (remotesOrManifestUrl: Manifest | string) => Promise<Manifest>;
+  provide: (
+    remotesOrManifestUrl: Manifest | string,
+    opts?: { integrity?: string }
+  ) => Promise<Manifest>;
 };

--- a/src/lib/2.app/driving-ports/for-providing-remote-entries.port.ts
+++ b/src/lib/2.app/driving-ports/for-providing-remote-entries.port.ts
@@ -1,5 +1,5 @@
 import type { RemoteEntry } from 'lib/1.domain/remote-entry/remote-entry.contract';
 
 export type ForProvidingRemoteEntries = {
-  provide: (remoteEntryUrl: string) => Promise<RemoteEntry>;
+  provide: (remoteEntryUrl: string, opts?: { integrity?: string }) => Promise<RemoteEntry>;
 };

--- a/src/lib/2.app/flows/dynamic-init/convert-to-import-map.integrity.spec.ts
+++ b/src/lib/2.app/flows/dynamic-init/convert-to-import-map.integrity.spec.ts
@@ -1,0 +1,164 @@
+import { LoggingConfig } from '../../config/log.contract';
+import { ForConvertingToImportMap } from 'lib/2.app/driver-ports/dynamic-init/for-converting-to-import-map';
+import { createConvertToImportMap } from './convert-to-import-map';
+import { RemoteEntry, SharedInfoActions } from 'lib/1.domain';
+import { mockConfig } from 'lib/6.mocks/config.mock';
+import { mockRemoteEntry_MFE2 } from 'lib/6.mocks/domain/remote-entry/remote-entry.mock';
+import { mockScopeUrl_MFE2 } from 'lib/6.mocks/domain/scope-url.mock';
+import {
+  mockSharedInfoA,
+  mockSharedInfoE,
+  mockSharedInfoF,
+} from 'lib/6.mocks/domain/remote-entry/shared-info.mock';
+import { mockChunkRepository } from 'lib/6.mocks/adapters/chunk.repository.mock';
+import { Optional } from 'lib/utils/optional';
+import { DrivingContract } from 'lib/2.app/driving-ports/driving.contract';
+
+const HASH_A = 'sha384-AAA';
+const HASH_E = 'sha384-EEE';
+const HASH_F = 'sha384-FFF';
+const HASH_COMP_B = 'sha384-CMP-B';
+const HASH_COMP_C = 'sha384-CMP-C';
+const HASH_CHUNK = 'sha384-CHK';
+
+describe('createConvertToImportMap (integrity)', () => {
+  let convertToImportMap: ForConvertingToImportMap;
+  let config: LoggingConfig;
+  let ports: Pick<DrivingContract, 'sharedChunksRepo'>;
+
+  beforeEach(() => {
+    config = mockConfig();
+    ports = { sharedChunksRepo: mockChunkRepository() };
+    convertToImportMap = createConvertToImportMap(config, ports);
+  });
+
+  it('should omit the integrity block when remoteEntry has no integrity map', async () => {
+    const entry: RemoteEntry = mockRemoteEntry_MFE2({ shared: [] });
+
+    const importMap = await convertToImportMap({ entry, actions: {} });
+
+    expect(importMap.integrity).toBeUndefined();
+  });
+
+  it('should add integrity for exposed remote modules', async () => {
+    const entry: RemoteEntry = mockRemoteEntry_MFE2({
+      shared: [],
+      integrity: { 'component-b.js': HASH_COMP_B, 'component-c.js': HASH_COMP_C },
+    });
+
+    const importMap = await convertToImportMap({ entry, actions: {} });
+
+    expect(importMap.integrity).toEqual({
+      [mockScopeUrl_MFE2({ file: 'component-b.js' })]: HASH_COMP_B,
+      [mockScopeUrl_MFE2({ file: 'component-c.js' })]: HASH_COMP_C,
+    });
+  });
+
+  it('should add integrity for non-singleton (scoped) shared externals', async () => {
+    const entry: RemoteEntry = mockRemoteEntry_MFE2({
+      exposes: [],
+      shared: [mockSharedInfoE.v1_2_3(), mockSharedInfoF.v1_2_4()],
+      integrity: { 'dep-e.js': HASH_E, 'dep-f.js': HASH_F },
+    });
+
+    const importMap = await convertToImportMap({ entry, actions: {} });
+
+    expect(importMap.integrity).toEqual({
+      [mockScopeUrl_MFE2({ file: 'dep-e.js' })]: HASH_E,
+      [mockScopeUrl_MFE2({ file: 'dep-f.js' })]: HASH_F,
+    });
+  });
+
+  it('should skip integrity entries when the file has no hash', async () => {
+    const entry: RemoteEntry = mockRemoteEntry_MFE2({
+      exposes: [],
+      shared: [mockSharedInfoE.v1_2_3(), mockSharedInfoF.v1_2_4()],
+      integrity: { 'dep-e.js': HASH_E },
+    });
+
+    const importMap = await convertToImportMap({ entry, actions: {} });
+
+    expect(importMap.integrity).toEqual({
+      [mockScopeUrl_MFE2({ file: 'dep-e.js' })]: HASH_E,
+    });
+  });
+
+  it('should add integrity for singleton scope-action externals', async () => {
+    const entry: RemoteEntry = mockRemoteEntry_MFE2({
+      exposes: [],
+      shared: [mockSharedInfoA.v2_1_2()],
+      integrity: { 'dep-a.js': HASH_A },
+    });
+    const actions: SharedInfoActions = { 'dep-a': { action: 'scope' } };
+
+    const importMap = await convertToImportMap({ entry, actions });
+
+    expect(importMap.integrity).toEqual({
+      [mockScopeUrl_MFE2({ file: 'dep-a.js' })]: HASH_A,
+    });
+  });
+
+  it('should add integrity for share-action externals with shareScope', async () => {
+    const entry: RemoteEntry = mockRemoteEntry_MFE2({
+      exposes: [],
+      shared: [mockSharedInfoA.v2_1_2({ shareScope: 'custom-scope' })],
+      integrity: { 'dep-a.js': HASH_A },
+    });
+    const actions: SharedInfoActions = { 'dep-a': { action: 'share' } };
+
+    const importMap = await convertToImportMap({ entry, actions });
+
+    expect(importMap.integrity).toEqual({
+      [mockScopeUrl_MFE2({ file: 'dep-a.js' })]: HASH_A,
+    });
+  });
+
+  it('should add integrity for globally shared singletons (default case)', async () => {
+    const entry: RemoteEntry = mockRemoteEntry_MFE2({
+      exposes: [],
+      shared: [mockSharedInfoA.v2_1_2()],
+      integrity: { 'dep-a.js': HASH_A },
+    });
+    const actions: SharedInfoActions = { 'dep-a': { action: 'share' } };
+
+    const importMap = await convertToImportMap({ entry, actions });
+
+    expect(importMap.integrity).toEqual({
+      [mockScopeUrl_MFE2({ file: 'dep-a.js' })]: HASH_A,
+    });
+  });
+
+  it('should not add integrity for skipped externals (no URL emitted)', async () => {
+    const entry: RemoteEntry = mockRemoteEntry_MFE2({
+      exposes: [],
+      shared: [mockSharedInfoA.v2_1_2()],
+      integrity: { 'dep-a.js': HASH_A },
+    });
+    const actions: SharedInfoActions = { 'dep-a': { action: 'skip' } };
+
+    const importMap = await convertToImportMap({ entry, actions });
+
+    expect(importMap.integrity).toBeUndefined();
+  });
+
+  it('should add integrity for chunk imports', async () => {
+    const entry: RemoteEntry = mockRemoteEntry_MFE2({
+      exposes: [],
+      shared: [],
+      chunks: { 'mapping-or-exposed': ['shared-chunk.js'] },
+      integrity: { 'shared-chunk.js': HASH_CHUNK },
+    });
+    ports.sharedChunksRepo.tryGet = jest.fn((remote, bundle) => {
+      if (remote === 'team/mfe2' && bundle === 'mapping-or-exposed') {
+        return Optional.of(['shared-chunk.js']);
+      }
+      return Optional.empty();
+    });
+
+    const importMap = await convertToImportMap({ entry, actions: {} });
+
+    expect(importMap.integrity).toEqual({
+      [mockScopeUrl_MFE2({ file: 'shared-chunk.js' })]: HASH_CHUNK,
+    });
+  });
+});

--- a/src/lib/2.app/flows/dynamic-init/convert-to-import-map.ts
+++ b/src/lib/2.app/flows/dynamic-init/convert-to-import-map.ts
@@ -29,17 +29,15 @@ export function createConvertToImportMap(
     }
 
     const remoteEntryScope = _path.getScope(remoteEntry.url);
+    const integrityMap = remoteEntry.integrity;
 
     const chunkBundles = new Set<string>(['mapping-or-exposed']);
     remoteEntry.shared.forEach(external => {
       // Scoped externals
       if (!external.singleton) {
-        addToScopes(
-          remoteEntryScope,
-          external.packageName,
-          _path.join(remoteEntryScope, external.outFileName),
-          importMap
-        );
+        const url = _path.join(remoteEntryScope, external.outFileName);
+        addToScopes(remoteEntryScope, external.packageName, url, importMap);
+        addIntegrity(importMap, url, integrityMap, external.outFileName);
         if (external?.bundle) chunkBundles.add(external?.bundle);
         return;
       }
@@ -72,31 +70,27 @@ export function createConvertToImportMap(
 
       //  Scoped shared externals
       if (actions[external.packageName]!.action === 'scope') {
-        addToScopes(
-          remoteEntryScope,
-          external.packageName,
-          _path.join(remoteEntryScope, external.outFileName),
-          importMap
-        );
+        const url = _path.join(remoteEntryScope, external.outFileName);
+        addToScopes(remoteEntryScope, external.packageName, url, importMap);
+        addIntegrity(importMap, url, integrityMap, external.outFileName);
         return;
       }
 
       // Shared externals with shareScope
       if (external.shareScope) {
-        addToScopes(
-          remoteEntryScope,
-          external.packageName,
-          _path.join(remoteEntryScope, external.outFileName),
-          importMap
-        );
+        const url = _path.join(remoteEntryScope, external.outFileName);
+        addToScopes(remoteEntryScope, external.packageName, url, importMap);
+        addIntegrity(importMap, url, integrityMap, external.outFileName);
         return;
       }
 
       // Default case: shared globally
-      importMap.imports[external.packageName] = _path.join(remoteEntryScope, external.outFileName);
+      const url = _path.join(remoteEntryScope, external.outFileName);
+      importMap.imports[external.packageName] = url;
+      addIntegrity(importMap, url, integrityMap, external.outFileName);
     });
 
-    addChunkImports(importMap, remoteEntry.name, remoteEntryScope, chunkBundles);
+    addChunkImports(importMap, remoteEntry, remoteEntryScope, chunkBundles);
   }
 
   function addToScopes(
@@ -118,27 +112,37 @@ export function createConvertToImportMap(
       const moduleName = _path.join(remoteEntry.name, exposed.key);
       const moduleUrl = _path.join(scope, exposed.outFileName);
       importMap.imports[moduleName] = moduleUrl;
+      addIntegrity(importMap, moduleUrl, remoteEntry.integrity, exposed.outFileName);
     });
   }
 
   function addChunkImports(
     importMap: ImportMap,
-    remoteName: string,
+    remoteEntry: RemoteEntry,
     remoteEntryScope: string,
     chunkBundles: Set<string>
   ) {
     Array.from(chunkBundles).forEach(bundleName => {
-      ports.sharedChunksRepo.tryGet(remoteName, bundleName).ifPresent(files => {
+      ports.sharedChunksRepo.tryGet(remoteEntry.name, bundleName).ifPresent(files => {
         files.forEach(file => {
-          addToScopes(
-            remoteEntryScope,
-            toChunkImport(file),
-            _path.join(remoteEntryScope, file),
-            importMap
-          );
+          const url = _path.join(remoteEntryScope, file);
+          addToScopes(remoteEntryScope, toChunkImport(file), url, importMap);
+          addIntegrity(importMap, url, remoteEntry.integrity, file);
         });
       });
     });
     return importMap;
+  }
+
+  function addIntegrity(
+    importMap: ImportMap,
+    url: string,
+    integrityMap: Record<string, string> | undefined,
+    file: string
+  ): void {
+    const hash = integrityMap?.[file];
+    if (!hash) return;
+    if (!importMap.integrity) importMap.integrity = {};
+    importMap.integrity[url] = hash;
   }
 }

--- a/src/lib/2.app/flows/dynamic-init/get-remote-entry.spec.ts
+++ b/src/lib/2.app/flows/dynamic-init/get-remote-entry.spec.ts
@@ -7,6 +7,7 @@ import { mockAdapters } from 'lib/6.mocks/adapters.mock';
 import { NFError } from 'lib/native-federation.error';
 import { mockRemoteEntry_MFE1 } from 'lib/6.mocks/domain/remote-entry/remote-entry.mock';
 import { mockScopeUrl_MFE1 } from 'lib/6.mocks/domain/scope-url.mock';
+import { RemoteInfo } from 'lib/1.domain';
 
 describe('createGetRemoteEntry', () => {
   let getRemoteEntry: ForGettingRemoteEntry;
@@ -51,8 +52,7 @@ describe('createGetRemoteEntry', () => {
     it('should skip fetching remote if it exists in repository and overrideCachedRemotes is never', async () => {
       config.profile.overrideCachedRemotes = 'never';
       adapters.remoteInfoRepo.tryGet = jest.fn(() =>
-        Optional.of({
-          name: 'team/mfe1',
+        Optional.of<RemoteInfo>({
           scopeUrl: mockScopeUrl_MFE1(),
           exposes: [],
         })
@@ -107,8 +107,7 @@ describe('createGetRemoteEntry', () => {
     it('should override fetching remote if it exists in repository and overrideCachedRemotes is always', async () => {
       config.profile.overrideCachedRemotes = 'always';
       adapters.remoteInfoRepo.tryGet = jest.fn(() =>
-        Optional.of({
-          name: 'team/mfe1',
+        Optional.of<RemoteInfo>({
           scopeUrl: mockScopeUrl_MFE1({ folder: 'v1' }),
           exposes: [],
         })
@@ -130,8 +129,7 @@ describe('createGetRemoteEntry', () => {
     it('should not override fetching remote if it exists in repository and overrideCachedRemotes is init-only', async () => {
       config.profile.overrideCachedRemotes = 'init-only';
       adapters.remoteInfoRepo.tryGet = jest.fn(() =>
-        Optional.of({
-          name: 'team/mfe1',
+        Optional.of<RemoteInfo>({
           scopeUrl: mockScopeUrl_MFE1({ folder: 'v1' }),
           exposes: [],
         })
@@ -151,8 +149,7 @@ describe('createGetRemoteEntry', () => {
     it('should not override fetching remote if it exists in repository and overrideCachedRemotes is never', async () => {
       config.profile.overrideCachedRemotes = 'never';
       adapters.remoteInfoRepo.tryGet = jest.fn(() =>
-        Optional.of({
-          name: 'team/mfe1',
+        Optional.of<RemoteInfo>({
           scopeUrl: mockScopeUrl_MFE1({ folder: 'v1' }),
           exposes: [],
         })
@@ -174,8 +171,7 @@ describe('createGetRemoteEntry', () => {
       config.profile.overrideCachedRemotesIfURLMatches = false;
 
       adapters.remoteInfoRepo.tryGet = jest.fn(() =>
-        Optional.of({
-          name: 'team/mfe1',
+        Optional.of<RemoteInfo>({
           scopeUrl: mockScopeUrl_MFE1({ folder: 'v1' }),
           exposes: [],
         })
@@ -198,8 +194,7 @@ describe('createGetRemoteEntry', () => {
       adapters.remoteInfoRepo.contains = jest.fn(() => true);
 
       adapters.remoteInfoRepo.tryGet = jest.fn(() =>
-        Optional.of({
-          name: 'team/mfe1',
+        Optional.of<RemoteInfo>({
           scopeUrl: mockScopeUrl_MFE1({ folder: 'v1' }),
           exposes: [],
         })
@@ -221,6 +216,39 @@ describe('createGetRemoteEntry', () => {
         url: mockScopeUrl_MFE1({ folder: 'v1', file: 'remoteEntry.json' }),
         override: true,
       });
+    });
+  });
+
+  describe('integrity', () => {
+    it('should pass integrity to provider when remote is given as object with integrity', async () => {
+      await getRemoteEntry(`${mockScopeUrl_MFE1()}remoteEntry.json`, {
+        name: 'team/mfe1',
+        integrity: 'sha384-AAA',
+      });
+
+      expect(adapters.remoteEntryProvider.provide).toHaveBeenCalledWith(
+        `${mockScopeUrl_MFE1()}remoteEntry.json`,
+        { integrity: 'sha384-AAA' }
+      );
+    });
+
+    it('should not pass an opts arg when remote has no integrity', async () => {
+      await getRemoteEntry(`${mockScopeUrl_MFE1()}remoteEntry.json`, 'team/mfe1');
+
+      expect(adapters.remoteEntryProvider.provide).toHaveBeenCalledWith(
+        `${mockScopeUrl_MFE1()}remoteEntry.json`
+      );
+    });
+
+    it('should accept an integrity-only ref (no name)', async () => {
+      await getRemoteEntry(`${mockScopeUrl_MFE1()}remoteEntry.json`, {
+        integrity: 'sha384-AAA',
+      });
+
+      expect(adapters.remoteEntryProvider.provide).toHaveBeenCalledWith(
+        `${mockScopeUrl_MFE1()}remoteEntry.json`,
+        { integrity: 'sha384-AAA' }
+      );
     });
   });
 });

--- a/src/lib/2.app/flows/dynamic-init/get-remote-entry.ts
+++ b/src/lib/2.app/flows/dynamic-init/get-remote-entry.ts
@@ -5,22 +5,35 @@ import type { LoggingConfig } from '../../config/log.contract';
 import { NFError } from 'lib/native-federation.error';
 import type { ModeConfig } from '../../config/mode.contract';
 import type { ForGettingRemoteEntry } from '../../driver-ports/dynamic-init/for-getting-remote-entry.port';
+import type { RemoteRef } from '../../driver-ports/dynamic-init/flow.contract';
 import { Optional } from 'lib/utils/optional';
 import type { RemoteEntry } from 'lib/1.domain';
 import * as _path from 'lib/utils/path';
+
+const normalizeRemoteRef = (
+  remote?: RemoteRef
+): { name?: RemoteName; integrity?: string } => {
+  if (!remote) return {};
+  if (typeof remote === 'string') return { name: remote };
+  return remote;
+};
 
 export function createGetRemoteEntry(
   config: LoggingConfig & ModeConfig,
   ports: Pick<DrivingContract, 'remoteEntryProvider' | 'remoteInfoRepo' | 'sse'>
 ): ForGettingRemoteEntry {
-  return async (remoteEntryUrl: RemoteEntryUrl, remoteName?: RemoteName) => {
+  return async (remoteEntryUrl: RemoteEntryUrl, remote?: RemoteRef) => {
+    const { name: remoteName, integrity } = normalizeRemoteRef(remote);
+
     if (!!remoteName && shouldSkipCachedRemote(remoteEntryUrl, remoteName)) {
       config.log.debug(7, `Found remote '${remoteName}' in storage, omitting fetch.`);
       return Optional.empty<RemoteEntry>();
     }
 
     try {
-      const remoteEntry = await ports.remoteEntryProvider.provide(remoteEntryUrl);
+      const remoteEntry = integrity
+        ? await ports.remoteEntryProvider.provide(remoteEntryUrl, { integrity })
+        : await ports.remoteEntryProvider.provide(remoteEntryUrl);
 
       config.log.debug(
         7,

--- a/src/lib/2.app/flows/init/generate-import-map.integrity.spec.ts
+++ b/src/lib/2.app/flows/init/generate-import-map.integrity.spec.ts
@@ -1,0 +1,227 @@
+import { ForGeneratingImportMap } from '../../driver-ports/init/for-generating-import-map';
+import { DrivingContract } from '../../driving-ports/driving.contract';
+import { createGenerateImportMap } from './generate-import-map';
+import { LoggingConfig } from '../../config/log.contract';
+import { ModeConfig } from '../../config/mode.contract';
+import { Optional } from 'lib/utils/optional';
+import { RemoteInfo } from 'lib/1.domain';
+import { mockConfig } from 'lib/6.mocks/config.mock';
+import { mockAdapters } from 'lib/6.mocks/adapters.mock';
+import {
+  mockRemoteInfo_MFE1,
+  mockRemoteInfo_MFE2,
+} from 'lib/6.mocks/domain/remote-info/remote-info.mock';
+import {
+  mockExternal_A,
+  mockExternal_E,
+  mockExternal_F,
+} from 'lib/6.mocks/domain/externals/external.mock';
+import { mockVersion_A } from 'lib/6.mocks/domain/externals/version.mock';
+import { mockScopeUrl_MFE1, mockScopeUrl_MFE2 } from 'lib/6.mocks/domain/scope-url.mock';
+
+const HASH_A = 'sha384-AAA';
+const HASH_B = 'sha384-BBB';
+const HASH_E = 'sha384-EEE';
+const HASH_F = 'sha384-FFF';
+const HASH_CHUNK = 'sha384-CHK';
+const HASH_COMP_A = 'sha384-CMP-A';
+const HASH_COMP_B = 'sha384-CMP-B';
+
+describe('createGenerateImportMap (integrity)', () => {
+  let generateImportMap: ForGeneratingImportMap;
+  let adapters: Pick<
+    DrivingContract,
+    'remoteInfoRepo' | 'scopedExternalsRepo' | 'sharedExternalsRepo' | 'sharedChunksRepo'
+  >;
+  let config: LoggingConfig & ModeConfig;
+
+  const remoteInfoFor = (
+    mfe: 'team/mfe1' | 'team/mfe2',
+    integrity?: Record<string, string>
+  ): RemoteInfo => {
+    const base = mfe === 'team/mfe1' ? mockRemoteInfo_MFE1() : mockRemoteInfo_MFE2();
+    return integrity ? { ...base, integrity } : base;
+  };
+
+  beforeEach(() => {
+    config = mockConfig();
+    adapters = mockAdapters();
+
+    adapters.remoteInfoRepo.getAll = jest.fn(() => ({}));
+    adapters.scopedExternalsRepo.getAll = jest.fn(() => ({}));
+    adapters.sharedExternalsRepo.getFromScope = jest.fn(() => ({}));
+    adapters.sharedExternalsRepo.getScopes = jest.fn(() => []);
+    adapters.sharedChunksRepo.tryGet = jest.fn(() => Optional.empty());
+    adapters.remoteInfoRepo.tryGet = jest.fn(() => Optional.empty<RemoteInfo>());
+
+    generateImportMap = createGenerateImportMap(config, adapters);
+  });
+
+  it('should omit the integrity block when no remote provides hashes', async () => {
+    adapters.remoteInfoRepo.tryGet = jest.fn(remote => {
+      if (remote === 'team/mfe1') return Optional.of(remoteInfoFor('team/mfe1'));
+      return Optional.empty<RemoteInfo>();
+    });
+    adapters.remoteInfoRepo.getAll = jest.fn(() => ({
+      'team/mfe1': remoteInfoFor('team/mfe1'),
+    }));
+
+    const actual = await generateImportMap();
+
+    expect(actual.integrity).toBeUndefined();
+  });
+
+  it('should add integrity for exposed remote modules', async () => {
+    const integrity = { 'component-a.js': HASH_COMP_A };
+    adapters.remoteInfoRepo.tryGet = jest.fn(remote => {
+      if (remote === 'team/mfe1') return Optional.of(remoteInfoFor('team/mfe1', integrity));
+      return Optional.empty<RemoteInfo>();
+    });
+    adapters.remoteInfoRepo.getAll = jest.fn(() => ({
+      'team/mfe1': remoteInfoFor('team/mfe1', integrity),
+    }));
+
+    const actual = await generateImportMap();
+
+    expect(actual.integrity).toEqual({
+      [mockScopeUrl_MFE1({ file: 'component-a.js' })]: HASH_COMP_A,
+    });
+  });
+
+  it('should add integrity for scoped externals', async () => {
+    const integrity = { 'dep-e.js': HASH_E, 'dep-f.js': HASH_F };
+    adapters.remoteInfoRepo.tryGet = jest.fn(remote => {
+      if (remote === 'team/mfe1')
+        return Optional.of(remoteInfoFor('team/mfe1', integrity));
+      return Optional.empty<RemoteInfo>();
+    });
+    adapters.scopedExternalsRepo.getAll = jest.fn(() => ({
+      'team/mfe1': { ...mockExternal_E(), ...mockExternal_F() },
+    }));
+
+    const actual = await generateImportMap();
+
+    expect(actual.integrity).toEqual({
+      [mockScopeUrl_MFE1({ file: 'dep-e.js' })]: HASH_E,
+      [mockScopeUrl_MFE1({ file: 'dep-f.js' })]: HASH_F,
+    });
+  });
+
+  it('should skip integrity entries when the file has no hash', async () => {
+    const integrity = { 'dep-e.js': HASH_E };
+    adapters.remoteInfoRepo.tryGet = jest.fn(remote => {
+      if (remote === 'team/mfe1')
+        return Optional.of(remoteInfoFor('team/mfe1', integrity));
+      return Optional.empty<RemoteInfo>();
+    });
+    adapters.scopedExternalsRepo.getAll = jest.fn(() => ({
+      'team/mfe1': { ...mockExternal_E(), ...mockExternal_F() },
+    }));
+
+    const actual = await generateImportMap();
+
+    expect(actual.integrity).toEqual({
+      [mockScopeUrl_MFE1({ file: 'dep-e.js' })]: HASH_E,
+    });
+  });
+
+  it('should add integrity for globally shared externals', async () => {
+    const integrity = { 'dep-a.js': HASH_A };
+    adapters.remoteInfoRepo.tryGet = jest.fn(remote => {
+      if (remote === 'team/mfe1')
+        return Optional.of(remoteInfoFor('team/mfe1', integrity));
+      return Optional.empty<RemoteInfo>();
+    });
+    adapters.sharedExternalsRepo.getFromScope = jest.fn(() => ({
+      'dep-a': mockExternal_A({
+        dirty: false,
+        versions: [mockVersion_A.v2_1_1({ action: 'share', remotes: ['team/mfe1'] })],
+      }),
+    }));
+
+    const actual = await generateImportMap();
+
+    expect(actual.integrity).toEqual({
+      [mockScopeUrl_MFE1({ file: 'dep-a.js' })]: HASH_A,
+    });
+  });
+
+  it('should add integrity for share-scope shared externals', async () => {
+    const integrity1 = { 'dep-a.js': HASH_A };
+    const integrity2 = { 'dep-b.js': HASH_B };
+    adapters.remoteInfoRepo.tryGet = jest.fn(remote => {
+      if (remote === 'team/mfe1') return Optional.of(remoteInfoFor('team/mfe1', integrity1));
+      if (remote === 'team/mfe2') return Optional.of(remoteInfoFor('team/mfe2', integrity2));
+      return Optional.empty<RemoteInfo>();
+    });
+    adapters.sharedExternalsRepo.getScopes = jest.fn(() => ['custom-scope']);
+    const sharedForScope = {
+      'dep-a': mockExternal_A({
+        dirty: false,
+        versions: [mockVersion_A.v2_1_1({ action: 'share', remotes: ['team/mfe1'] })],
+      }),
+    };
+    adapters.sharedExternalsRepo.getFromScope = jest.fn(scope =>
+      scope === 'custom-scope' ? sharedForScope : {}
+    );
+
+    const actual = await generateImportMap();
+
+    expect(actual.integrity).toEqual({
+      [mockScopeUrl_MFE1({ file: 'dep-a.js' })]: HASH_A,
+    });
+  });
+
+  it('should add integrity for chunk imports', async () => {
+    const integrity = { 'dep-a.js': HASH_A, 'shared-chunk.js': HASH_CHUNK };
+    adapters.remoteInfoRepo.tryGet = jest.fn(remote => {
+      if (remote === 'team/mfe1') return Optional.of(remoteInfoFor('team/mfe1', integrity));
+      return Optional.empty<RemoteInfo>();
+    });
+    adapters.sharedExternalsRepo.getFromScope = jest.fn(() => ({
+      'dep-a': mockExternal_A({
+        dirty: false,
+        versions: [
+          mockVersion_A.v2_1_1({
+            action: 'share',
+            remotes: { 'team/mfe1': { bundle: 'shared' } },
+          }),
+        ],
+      }),
+    }));
+    adapters.sharedChunksRepo.tryGet = jest.fn((remote, bundle) => {
+      if (remote === 'team/mfe1' && bundle === 'shared') {
+        return Optional.of(['shared-chunk.js']);
+      }
+      return Optional.empty();
+    });
+
+    const actual = await generateImportMap();
+
+    expect(actual.integrity).toEqual({
+      [mockScopeUrl_MFE1({ file: 'dep-a.js' })]: HASH_A,
+      [mockScopeUrl_MFE1({ file: 'shared-chunk.js' })]: HASH_CHUNK,
+    });
+  });
+
+  it('should add integrity across multiple remotes', async () => {
+    const integrity1 = { 'component-a.js': HASH_COMP_A };
+    const integrity2 = { 'component-b.js': HASH_COMP_B };
+    adapters.remoteInfoRepo.tryGet = jest.fn(remote => {
+      if (remote === 'team/mfe1') return Optional.of(remoteInfoFor('team/mfe1', integrity1));
+      if (remote === 'team/mfe2') return Optional.of(remoteInfoFor('team/mfe2', integrity2));
+      return Optional.empty<RemoteInfo>();
+    });
+    adapters.remoteInfoRepo.getAll = jest.fn(() => ({
+      'team/mfe1': remoteInfoFor('team/mfe1', integrity1),
+      'team/mfe2': remoteInfoFor('team/mfe2', integrity2),
+    }));
+
+    const actual = await generateImportMap();
+
+    expect(actual.integrity).toEqual({
+      [mockScopeUrl_MFE1({ file: 'component-a.js' })]: HASH_COMP_A,
+      [mockScopeUrl_MFE2({ file: 'component-b.js' })]: HASH_COMP_B,
+    });
+  });
+});

--- a/src/lib/2.app/flows/init/generate-import-map.ts
+++ b/src/lib/2.app/flows/init/generate-import-map.ts
@@ -63,6 +63,10 @@ export function createGenerateImportMap(
       });
       addToScope(importMap, remote.scopeUrl, createScopeModules(externals, remote.scopeUrl));
 
+      for (const version of Object.values(externals)) {
+        addIntegrity(importMap, _path.join(remote.scopeUrl, version.file), remoteName, version.file);
+      }
+
       Object.values(externals)
         .filter(e => !!e.bundle)
         .forEach(e => registerBundleChunks(chunkBundles, remoteName, e.bundle));
@@ -114,9 +118,11 @@ export function createGenerateImportMap(
         if (version.action === 'scope') {
           for (const remote of version.remotes) {
             const remoteScope = getScope(shareScope, remote.name, externalName);
+            const url = _path.join(remoteScope, remote.file);
             addToScope(importMap, remoteScope, {
-              [externalName]: _path.join(remoteScope, remote.file),
+              [externalName]: url,
             });
+            addIntegrity(importMap, url, remote.name, remote.file);
             registerBundleChunks(chunkBundles, remote.name, remote.bundle);
             remote.cached = true;
           }
@@ -126,6 +132,10 @@ export function createGenerateImportMap(
         const scope = getScope(shareScope, version.remotes[0]!.name, externalName);
 
         let targetFileUrl: string = _path.join(scope, version.remotes[0]!.file);
+        let targetFileSource: { name: RemoteName; file: string } = {
+          name: version.remotes[0]!.name,
+          file: version.remotes[0]!.file,
+        };
         version.remotes[0]!.cached = true;
 
         if (version.action === 'share') {
@@ -140,6 +150,10 @@ export function createGenerateImportMap(
             if (!overrideScope)
               overrideScope = getScope(shareScope, override.remotes[0]!.name, externalName);
             targetFileUrl = _path.join(overrideScope, override.remotes[0]!.file);
+            targetFileSource = {
+              name: override.remotes[0]!.name,
+              file: override.remotes[0]!.file,
+            };
             override.remotes[0]!.cached = true;
 
             version.remotes[0]!.cached = false;
@@ -149,6 +163,7 @@ export function createGenerateImportMap(
           const scope = getScope(shareScope, r.name, externalName);
           addToScope(importMap, scope, { [externalName]: targetFileUrl });
         });
+        addIntegrity(importMap, targetFileUrl, targetFileSource.name, targetFileSource.file);
       }
       ports.sharedExternalsRepo.addOrUpdate(externalName, external, shareScope);
     }
@@ -209,9 +224,11 @@ export function createGenerateImportMap(
         if (version.action === 'scope') {
           for (const remote of version.remotes) {
             const remoteScope = getScope(GLOBAL_SCOPE, remote.name, externalName);
+            const url = _path.join(remoteScope, remote.file);
             addToScope(importMap, remoteScope, {
-              [externalName]: _path.join(remoteScope, remote.file),
+              [externalName]: url,
             });
+            addIntegrity(importMap, url, remote.name, remote.file);
             remote.cached = true;
             registerBundleChunks(chunkBundles, remote.name, remote.bundle);
           }
@@ -224,7 +241,9 @@ export function createGenerateImportMap(
         }
 
         const scope = getScope(GLOBAL_SCOPE, version.remotes[0]!.name, externalName);
-        addToGlobal(importMap, { [externalName]: _path.join(scope, version.remotes[0]!.file) });
+        const url = _path.join(scope, version.remotes[0]!.file);
+        addToGlobal(importMap, { [externalName]: url });
+        addIntegrity(importMap, url, version.remotes[0]!.name, version.remotes[0]!.file);
         registerBundleChunks(chunkBundles, version.remotes[0]!.name, version.remotes[0]!.bundle);
 
         version.remotes[0]!.cached = true;
@@ -276,6 +295,7 @@ export function createGenerateImportMap(
       const moduleName = _path.join(remoteName, exposed.moduleName);
       const moduleUrl = _path.join(remote.scopeUrl, exposed.file);
       importMap.imports[moduleName] = moduleUrl;
+      addIntegrity(importMap, moduleUrl, remoteName, exposed.file);
     }
   }
 
@@ -297,7 +317,9 @@ export function createGenerateImportMap(
       const imports = Array.from(bundles).reduce((_imports, bundleName) => {
         ports.sharedChunksRepo.tryGet(remoteName, bundleName).ifPresent(files => {
           files.forEach(file => {
-            _imports[toChunkImport(file)] = _path.join(baseUrl, file);
+            const url = _path.join(baseUrl, file);
+            _imports[toChunkImport(file)] = url;
+            addIntegrity(importMap, url, remoteName, file);
           });
         });
         return _imports;
@@ -307,6 +329,18 @@ export function createGenerateImportMap(
     });
 
     return importMap;
+  }
+
+  function addIntegrity(
+    importMap: ImportMap,
+    url: string,
+    remoteName: RemoteName,
+    file: string
+  ): void {
+    const hash = ports.remoteInfoRepo.tryGet(remoteName).get()?.integrity?.[file];
+    if (!hash) return;
+    if (!importMap.integrity) importMap.integrity = {};
+    importMap.integrity[url] = hash;
   }
 
   function getScope(ctx: string, remoteName: RemoteName, externalName?: string) {

--- a/src/lib/2.app/flows/init/get-remote-entries.spec.ts
+++ b/src/lib/2.app/flows/init/get-remote-entries.spec.ts
@@ -338,4 +338,62 @@ describe('createGetRemoteEntries', () => {
       );
     });
   });
+
+  describe('integrity', () => {
+    it('should accept manifest entries in object form with integrity', async () => {
+      await getRemoteEntries({
+        'team/mfe1': {
+          url: `${mockScopeUrl_MFE1()}remoteEntry.json`,
+          integrity: 'sha384-AAA',
+        },
+      });
+
+      expect(adapters.remoteEntryProvider.provide).toHaveBeenCalledWith(
+        `${mockScopeUrl_MFE1()}remoteEntry.json`,
+        { integrity: 'sha384-AAA' }
+      );
+    });
+
+    it('should not pass an opts arg when manifest entry has no integrity', async () => {
+      await getRemoteEntries({
+        'team/mfe1': `${mockScopeUrl_MFE1()}remoteEntry.json`,
+      });
+
+      expect(adapters.remoteEntryProvider.provide).toHaveBeenCalledWith(
+        `${mockScopeUrl_MFE1()}remoteEntry.json`
+      );
+    });
+
+    it('should pass manifestIntegrity to the manifest provider when configured', async () => {
+      config.manifestIntegrity = 'sha384-MAN';
+
+      await getRemoteEntries('http://host/manifest.json');
+
+      expect(adapters.manifestProvider.provide).toHaveBeenCalledWith(
+        'http://host/manifest.json',
+        { integrity: 'sha384-MAN' }
+      );
+    });
+
+    it('should propagate hostRemoteEntry integrity to the provider', async () => {
+      config.hostRemoteEntry = {
+        name: 'team/host',
+        url: `${mockScopeUrl_HOST()}remoteEntry.json`,
+        integrity: 'sha384-HOST',
+      };
+      adapters.remoteEntryProvider.provide = jest.fn((url: string) => {
+        if (url.startsWith(`${mockScopeUrl_HOST()}remoteEntry.json`)) {
+          return Promise.resolve(mockRemoteEntry_HOST());
+        }
+        return Promise.reject(new NFError(`Fetch of '${url}' returned 404`));
+      });
+
+      await getRemoteEntries({});
+
+      expect(adapters.remoteEntryProvider.provide).toHaveBeenCalledWith(
+        `${mockScopeUrl_HOST()}remoteEntry.json`,
+        { integrity: 'sha384-HOST' }
+      );
+    });
+  });
 });

--- a/src/lib/2.app/flows/init/get-remote-entries.ts
+++ b/src/lib/2.app/flows/init/get-remote-entries.ts
@@ -1,5 +1,9 @@
 import type { RemoteEntry } from 'lib/1.domain/remote-entry/remote-entry.contract';
-import type { Manifest, RemoteEntryUrl } from 'lib/1.domain/remote-entry/manifest.contract';
+import type {
+  Manifest,
+  RemoteEntryDescriptor,
+  RemoteEntryUrl,
+} from 'lib/1.domain/remote-entry/manifest.contract';
 import type { RemoteName } from 'lib/1.domain/remote/remote-info.contract';
 import type { ForGettingRemoteEntries } from '../../driver-ports/init/for-getting-remote-entries.port';
 import type { DrivingContract } from '../../driving-ports/driving.contract';
@@ -27,9 +31,14 @@ export function createGetRemoteEntries(
    * @param adapters
    * @returns A list of the remoteEntry json objects
    */
-  return (remotesOrManifestUrl = {}) =>
-    ports.manifestProvider
-      .provide(remotesOrManifestUrl)
+  return (remotesOrManifestUrl = {}) => {
+    const manifestPromise = config.manifestIntegrity
+      ? ports.manifestProvider.provide(remotesOrManifestUrl, {
+          integrity: config.manifestIntegrity,
+        })
+      : ports.manifestProvider.provide(remotesOrManifestUrl);
+
+    return manifestPromise
       .catch(e => {
         config.log.error(1, 'Could not fetch manifest.', e);
         return Promise.reject(new NFError('Failed to fetch manifest'));
@@ -38,30 +47,39 @@ export function createGetRemoteEntries(
       .then(fetchRemoteEntries)
       .then(removeSkippedRemotes)
       .then(checkForSSE);
+  };
 
   function addHostRemoteEntry(manifest: Manifest): Manifest {
     if (!config.hostRemoteEntry) return manifest;
 
-    const { name, url, cacheTag } = config.hostRemoteEntry;
+    const { name, url, cacheTag, integrity } = config.hostRemoteEntry;
     const urlWithCache = cacheTag ? `${url}?cacheTag=${cacheTag}` : url;
 
     return {
       ...manifest,
-      [name]: urlWithCache,
+      [name]: integrity ? { url: urlWithCache, integrity } : urlWithCache,
     };
   }
 
+  function normalizeEntry(descriptor: RemoteEntryDescriptor): {
+    url: RemoteEntryUrl;
+    integrity?: string;
+  } {
+    return typeof descriptor === 'string' ? { url: descriptor } : descriptor;
+  }
+
   async function fetchRemoteEntries(manifest: Manifest): Promise<(RemoteEntry | false)[]> {
-    const fetchPromises = Object.entries(manifest).map(([remoteName, remoteEntryUrl]) =>
-      fetchRemoteEntry(remoteName, remoteEntryUrl)
+    const fetchPromises = Object.entries(manifest).map(([remoteName, descriptor]) =>
+      fetchRemoteEntry(remoteName, descriptor)
     );
     return Promise.all(fetchPromises);
   }
 
   async function fetchRemoteEntry(
     remoteName: RemoteName,
-    remoteEntryUrl: RemoteEntryUrl
+    descriptor: RemoteEntryDescriptor
   ): Promise<RemoteEntry | false> {
+    const { url: remoteEntryUrl, integrity } = normalizeEntry(descriptor);
     let isOverride = false;
     let skip = false;
 
@@ -82,7 +100,9 @@ export function createGetRemoteEntries(
     if (skip) return false;
 
     try {
-      const remoteEntry = await ports.remoteEntryProvider.provide(remoteEntryUrl);
+      const remoteEntry = integrity
+        ? await ports.remoteEntryProvider.provide(remoteEntryUrl, { integrity })
+        : await ports.remoteEntryProvider.provide(remoteEntryUrl);
 
       config.log.debug(
         1,

--- a/src/lib/2.app/flows/init/process-remote-entries.spec.ts
+++ b/src/lib/2.app/flows/init/process-remote-entries.spec.ts
@@ -73,6 +73,28 @@ describe('createProcessRemoteEntries', () => {
         exposes: [mockRemoteModuleA()],
       });
     });
+
+    it('should propagate the integrity map onto the stored RemoteInfo', async () => {
+      const integrity = { 'component-a.js': 'sha384-CMP-A' };
+      const remoteEntries = [mockRemoteEntry_MFE1({ integrity })];
+
+      await processRemoteEntries(remoteEntries);
+
+      expect(adapters.remoteInfoRepo.addOrUpdate).toHaveBeenCalledWith('team/mfe1', {
+        scopeUrl: mockScopeUrl_MFE1(),
+        exposes: [mockRemoteModuleA()],
+        integrity,
+      });
+    });
+
+    it('should omit integrity from the stored RemoteInfo when remoteEntry has none', async () => {
+      const remoteEntries = [mockRemoteEntry_MFE1()];
+
+      await processRemoteEntries(remoteEntries);
+
+      const stored = (adapters.remoteInfoRepo.addOrUpdate as jest.Mock).mock.calls[0][1];
+      expect(stored).not.toHaveProperty('integrity');
+    });
   });
 
   describe('handling a missing version property', () => {

--- a/src/lib/2.app/flows/init/process-remote-entries.ts
+++ b/src/lib/2.app/flows/init/process-remote-entries.ts
@@ -59,13 +59,14 @@ export function createProcessRemoteEntries(
     ports.sharedExternalsRepo.removeFromAllScopes(remoteEntry.name);
   }
 
-  function addRemoteInfoToStorage({ name, url, exposes }: RemoteEntry): void {
+  function addRemoteInfoToStorage({ name, url, exposes, integrity }: RemoteEntry): void {
     ports.remoteInfoRepo.addOrUpdate(name, {
       scopeUrl: _path.getScope(url),
       exposes: Object.values(exposes ?? []).map(m => ({
         moduleName: m.key,
         file: m.outFileName,
       })),
+      ...(integrity ? { integrity } : {}),
     } as RemoteInfo);
   }
 

--- a/src/lib/3.adapters/http/manifest-provider.integrity.spec.ts
+++ b/src/lib/3.adapters/http/manifest-provider.integrity.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment node
+ */
+import { createManifestProvider } from './manifest-provider';
+import { ForProvidingManifest } from 'lib/2.app/driving-ports/for-providing-manifest.port';
+import { NFError } from 'lib/native-federation.error';
+
+const sriOf = async (input: string): Promise<string> => {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-384', bytes);
+  const view = new Uint8Array(digest);
+  let bin = '';
+  for (let i = 0; i < view.length; i++) bin += String.fromCharCode(view[i]!);
+  return 'sha384-' + btoa(bin);
+};
+
+const mockBytesFetch = (body: string) => {
+  global.fetch = jest.fn(async () => {
+    const bytes = new TextEncoder().encode(body);
+    return {
+      ok: true,
+      status: 200,
+      arrayBuffer: () => Promise.resolve(bytes.buffer),
+      json: () => Promise.resolve(JSON.parse(body)),
+    } as Response;
+  }) as jest.Mock;
+};
+
+describe('createManifestProvider (integrity)', () => {
+  let provider: ForProvidingManifest;
+
+  beforeEach(() => {
+    provider = createManifestProvider();
+  });
+
+  it('should pass through object manifests untouched even when integrity is given', async () => {
+    const manifest = { 'team/mfe1': 'http://my.service/mfe1/remoteEntry.json' };
+
+    const result = await provider.provide(manifest, { integrity: 'sha384-AAA' });
+
+    expect(result).toEqual(manifest);
+  });
+
+  it('should resolve when manifest URL matches integrity', async () => {
+    const manifest = { 'team/mfe1': 'http://my.service/mfe1/remoteEntry.json' };
+    const body = JSON.stringify(manifest);
+    mockBytesFetch(body);
+    const integrity = await sriOf(body);
+
+    const result = await provider.provide('http://host/manifest.json', { integrity });
+
+    expect(result).toEqual(manifest);
+  });
+
+  it('should reject with NFError when manifest integrity does not match', async () => {
+    const body = JSON.stringify({ 'team/mfe1': 'http://my.service/mfe1/remoteEntry.json' });
+    mockBytesFetch(body);
+
+    await expect(
+      provider.provide('http://host/manifest.json', {
+        integrity: 'sha384-' + 'A'.repeat(64),
+      })
+    ).rejects.toThrow(NFError);
+  });
+});

--- a/src/lib/3.adapters/http/manifest-provider.ts
+++ b/src/lib/3.adapters/http/manifest-provider.ts
@@ -1,24 +1,38 @@
 import type { Manifest } from 'lib/1.domain';
 import type { ForProvidingManifest } from 'lib/2.app/driving-ports/for-providing-manifest.port';
 import { NFError } from 'lib/native-federation.error';
+import { verifyIntegrity } from 'lib/utils/integrity';
 
 const createManifestProvider = (): ForProvidingManifest => {
-  const mapToJson = (response: Response) => {
+  const ensureOk = (response: Response) => {
     if (!response.ok)
       return Promise.reject(new NFError(`${response.status} - ${response.statusText}`));
-    return response.json() as Promise<Manifest>;
+    return response;
   };
 
-  const formatError = (remoteEntryUrl: string) => (err: unknown) => {
+  const formatError = (manifestUrl: string) => (err: unknown) => {
     const msg = err instanceof Error ? err.message : String(err);
-    throw new NFError(`Fetch of '${remoteEntryUrl}' returned ${msg}`);
+    throw new NFError(`Fetch of '${manifestUrl}' returned ${msg}`);
   };
 
   return {
-    provide: async function (remotesOrManifestUrl: string | Manifest) {
+    provide: async function (
+      remotesOrManifestUrl: string | Manifest,
+      opts: { integrity?: string } = {}
+    ) {
       if (typeof remotesOrManifestUrl !== 'string') return Promise.resolve(remotesOrManifestUrl);
 
-      return fetch(remotesOrManifestUrl).then(mapToJson).catch(formatError(remotesOrManifestUrl));
+      const parse = async (response: Response): Promise<Manifest> => {
+        if (!opts.integrity) return response.json() as Promise<Manifest>;
+        const bytes = await response.arrayBuffer();
+        await verifyIntegrity(bytes, opts.integrity);
+        return JSON.parse(new TextDecoder().decode(bytes)) as Manifest;
+      };
+
+      return fetch(remotesOrManifestUrl)
+        .then(ensureOk)
+        .then(parse)
+        .catch(formatError(remotesOrManifestUrl));
     },
   };
 };

--- a/src/lib/3.adapters/http/remote-entry-provider.integrity.spec.ts
+++ b/src/lib/3.adapters/http/remote-entry-provider.integrity.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+import { createRemoteEntryProvider } from './remote-entry-provider';
+import { ForProvidingRemoteEntries } from 'lib/2.app/driving-ports/for-providing-remote-entries.port';
+import { mockFederationInfo_MFE1 } from 'lib/6.mocks/domain/remote-entry/federation-info.mock';
+import { mockRemoteEntry_MFE1 } from 'lib/6.mocks/domain/remote-entry/remote-entry.mock';
+import { mockScopeUrl_MFE1 } from 'lib/6.mocks/domain/scope-url.mock';
+import { NFError } from 'lib/native-federation.error';
+
+const sriOf = async (input: string): Promise<string> => {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-384', bytes);
+  const view = new Uint8Array(digest);
+  let bin = '';
+  for (let i = 0; i < view.length; i++) bin += String.fromCharCode(view[i]!);
+  return 'sha384-' + btoa(bin);
+};
+
+const mockBytesFetch = (body: string) => {
+  global.fetch = jest.fn(async () => {
+    const bytes = new TextEncoder().encode(body);
+    return {
+      ok: true,
+      status: 200,
+      arrayBuffer: () => Promise.resolve(bytes.buffer),
+      json: () => Promise.resolve(JSON.parse(body)),
+    } as Response;
+  }) as jest.Mock;
+};
+
+describe('createRemoteEntryProvider (integrity)', () => {
+  let provider: ForProvidingRemoteEntries;
+
+  beforeEach(() => {
+    provider = createRemoteEntryProvider();
+  });
+
+  it('should fetch without integrity verification when no integrity is provided', async () => {
+    const body = JSON.stringify(mockFederationInfo_MFE1());
+    mockBytesFetch(body);
+
+    const result = await provider.provide(`${mockScopeUrl_MFE1()}remoteEntry.json`);
+
+    expect(result).toEqual(mockRemoteEntry_MFE1());
+  });
+
+  it('should resolve when integrity matches', async () => {
+    const body = JSON.stringify(mockFederationInfo_MFE1());
+    const integrity = await sriOf(body);
+    mockBytesFetch(body);
+
+    const result = await provider.provide(`${mockScopeUrl_MFE1()}remoteEntry.json`, {
+      integrity,
+    });
+
+    expect(result).toEqual(mockRemoteEntry_MFE1());
+  });
+
+  it('should reject with NFError when integrity does not match', async () => {
+    const body = JSON.stringify(mockFederationInfo_MFE1());
+    mockBytesFetch(body);
+
+    await expect(
+      provider.provide(`${mockScopeUrl_MFE1()}remoteEntry.json`, {
+        integrity: 'sha384-' + 'A'.repeat(64),
+      })
+    ).rejects.toThrow(NFError);
+  });
+
+  it('should reject with NFError when integrity prefix is unsupported', async () => {
+    const body = JSON.stringify(mockFederationInfo_MFE1());
+    mockBytesFetch(body);
+
+    await expect(
+      provider.provide(`${mockScopeUrl_MFE1()}remoteEntry.json`, {
+        integrity: 'md5-abcdef',
+      })
+    ).rejects.toThrow(/Unsupported integrity prefix/);
+  });
+});

--- a/src/lib/3.adapters/http/remote-entry-provider.ts
+++ b/src/lib/3.adapters/http/remote-entry-provider.ts
@@ -1,12 +1,13 @@
 import type { RemoteEntry } from 'lib/1.domain/remote-entry/remote-entry.contract';
 import type { ForProvidingRemoteEntries } from 'lib/2.app/driving-ports/for-providing-remote-entries.port';
 import { NFError } from 'lib/native-federation.error';
+import { verifyIntegrity } from 'lib/utils/integrity';
 
 const createRemoteEntryProvider = (): ForProvidingRemoteEntries => {
-  const mapToJson = (response: Response) => {
+  const ensureOk = (response: Response) => {
     if (!response.ok)
       return Promise.reject(new Error(`${response.status} - ${response.statusText}`));
-    return response.json() as Promise<RemoteEntry>;
+    return response;
   };
 
   const fillEmptyFields = (remoteEntryUrl: string) => (remoteEntry: RemoteEntry) => {
@@ -22,9 +23,17 @@ const createRemoteEntryProvider = (): ForProvidingRemoteEntries => {
   };
 
   return {
-    provide: async function (remoteEntryUrl: string) {
+    provide: async function (remoteEntryUrl: string, opts: { integrity?: string } = {}) {
+      const parse = async (response: Response): Promise<RemoteEntry> => {
+        if (!opts.integrity) return response.json() as Promise<RemoteEntry>;
+        const bytes = await response.arrayBuffer();
+        await verifyIntegrity(bytes, opts.integrity);
+        return JSON.parse(new TextDecoder().decode(bytes)) as RemoteEntry;
+      };
+
       return fetch(remoteEntryUrl)
-        .then(mapToJson)
+        .then(ensureOk)
+        .then(parse)
         .then(fillEmptyFields(remoteEntryUrl))
         .catch(formatError(remoteEntryUrl));
     },

--- a/src/lib/4.config/host/host.config.ts
+++ b/src/lib/4.config/host/host.config.ts
@@ -1,8 +1,12 @@
 import type { HostConfig, HostOptions } from 'lib/2.app/config/host.contract';
 
 export const createHostConfig = (override: Partial<HostOptions>): HostConfig => {
+  const extras = override?.manifestIntegrity
+    ? { manifestIntegrity: override.manifestIntegrity }
+    : {};
+
   if (!override?.hostRemoteEntry) {
-    return { hostRemoteEntry: false };
+    return { hostRemoteEntry: false, ...extras };
   }
   if (typeof override.hostRemoteEntry === 'string') {
     return {
@@ -10,6 +14,7 @@ export const createHostConfig = (override: Partial<HostOptions>): HostConfig => 
         name: '__NF-HOST__',
         url: override.hostRemoteEntry,
       },
+      ...extras,
     };
   }
   return {
@@ -17,5 +22,6 @@ export const createHostConfig = (override: Partial<HostOptions>): HostConfig => 
       name: '__NF-HOST__',
       ...override.hostRemoteEntry,
     },
+    ...extras,
   };
 };

--- a/src/lib/4.config/import-map/import-map.config.ts
+++ b/src/lib/4.config/import-map/import-map.config.ts
@@ -2,7 +2,7 @@ import type { ImportMapConfig, ImportMapOptions } from 'lib/2.app/config/import-
 import { useDefaultImportMap } from './use-default';
 
 export const createImportMapConfig = (o: Partial<ImportMapOptions>): ImportMapConfig => {
-  const fallback = useDefaultImportMap();
+  const fallback = useDefaultImportMap(o.trustedTypesPolicyName);
   return {
     setImportMapFn: o.setImportMapFn ?? fallback.setImportMapFn,
     loadModuleFn: o.loadModuleFn ?? fallback.loadModuleFn,

--- a/src/lib/4.config/import-map/replace-in-dom.spec.ts
+++ b/src/lib/4.config/import-map/replace-in-dom.spec.ts
@@ -1,5 +1,6 @@
 import { mockImportMap } from 'lib/6.mocks/domain/import-map.mock';
 import { replaceInDOM } from './replace-in-dom';
+import { __resetTrustedTypesPolicyForTests } from './trusted-types';
 import { ImportMap } from 'lib/1.domain';
 
 describe('replaceInBrowser', () => {
@@ -7,9 +8,15 @@ describe('replaceInBrowser', () => {
 
   beforeEach(() => {
     document.head.innerHTML = '';
+    __resetTrustedTypesPolicyForTests();
 
     jest.spyOn(document.head, 'appendChild');
     config = replaceInDOM('custom-importmap');
+  });
+
+  afterEach(() => {
+    delete (globalThis as { trustedTypes?: unknown }).trustedTypes;
+    __resetTrustedTypesPolicyForTests();
   });
 
   it('should create a new script element with correct type', () => {
@@ -84,5 +91,26 @@ describe('replaceInBrowser', () => {
     const scripts = document.head.querySelectorAll('script[type="custom-importmap"]');
     expect(scripts.length).toBe(1);
     expect(scripts[0]!.innerHTML).toBe(JSON.stringify(importMap));
+  });
+
+  it('should route the import map through a Trusted Types policy when available', () => {
+    const createScript = jest.fn((s: string) => s);
+    const createPolicy = jest.fn(() => ({ createScript, createScriptURL: (s: string) => s }));
+    (globalThis as { trustedTypes?: unknown }).trustedTypes = { createPolicy };
+
+    const importMap = mockImportMap();
+    replaceInDOM('custom-importmap', 'my-policy')(importMap);
+
+    expect(createPolicy).toHaveBeenCalledWith('my-policy', expect.any(Object));
+    expect(createScript).toHaveBeenCalledWith(JSON.stringify(importMap));
+  });
+
+  it('should not create a policy when the policy name is false', () => {
+    const createPolicy = jest.fn();
+    (globalThis as { trustedTypes?: unknown }).trustedTypes = { createPolicy };
+
+    replaceInDOM('custom-importmap', false)(mockImportMap());
+
+    expect(createPolicy).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/4.config/import-map/replace-in-dom.ts
+++ b/src/lib/4.config/import-map/replace-in-dom.ts
@@ -1,8 +1,9 @@
 import type { ImportMap } from 'lib/1.domain';
 import type { SetImportMap } from 'lib/2.app/config/import-map.contract';
+import { getTrustedTypesPolicy } from './trusted-types';
 
 export const replaceInDOM =
-  (mapType: string): SetImportMap =>
+  (mapType: string, trustedTypesPolicyName: string | false = 'nfo'): SetImportMap =>
   (importMap: ImportMap, opts = {}) => {
     if (opts?.override) {
       document.head
@@ -10,10 +11,11 @@ export const replaceInDOM =
         .forEach(importMap => importMap.remove());
     }
 
+    const policy = getTrustedTypesPolicy(trustedTypesPolicyName);
     document.head.appendChild(
       Object.assign(document.createElement('script'), {
         type: mapType,
-        innerHTML: JSON.stringify(importMap),
+        text: policy.createScript(JSON.stringify(importMap)),
       })
     );
     return Promise.resolve(importMap);

--- a/src/lib/4.config/import-map/trusted-types.spec.ts
+++ b/src/lib/4.config/import-map/trusted-types.spec.ts
@@ -1,0 +1,148 @@
+import {
+  __resetTrustedTypesPolicyForTests,
+  getTrustedTypesPolicy,
+} from './trusted-types';
+
+describe('getTrustedTypesPolicy', () => {
+  afterEach(() => {
+    delete (globalThis as { trustedTypes?: unknown }).trustedTypes;
+    __resetTrustedTypesPolicyForTests();
+  });
+
+  describe('when globalThis.trustedTypes is unavailable', () => {
+    it('returns a transparent pass-through for createScript', () => {
+      const policy = getTrustedTypesPolicy();
+      expect(policy.createScript('{"imports":{}}')).toBe('{"imports":{}}');
+    });
+
+    it('returns a transparent pass-through for createScriptURL', () => {
+      const policy = getTrustedTypesPolicy();
+      expect(policy.createScriptURL('https://example.test/a.js')).toBe(
+        'https://example.test/a.js'
+      );
+    });
+
+    it('does not validate input when no native factory exists', () => {
+      const policy = getTrustedTypesPolicy();
+      // would otherwise be rejected by the policy validator
+      expect(policy.createScript('not json')).toBe('not json');
+      expect(policy.createScriptURL('javascript:alert(1)')).toBe('javascript:alert(1)');
+    });
+  });
+
+  describe('when policy name is false', () => {
+    it('returns the pass-through policy even if a native factory exists', () => {
+      const createPolicy = jest.fn();
+      (globalThis as { trustedTypes?: unknown }).trustedTypes = { createPolicy };
+
+      const policy = getTrustedTypesPolicy(false);
+      expect(policy.createScript('whatever')).toBe('whatever');
+      expect(createPolicy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when globalThis.trustedTypes is available', () => {
+    let createPolicy: jest.Mock;
+
+    beforeEach(() => {
+      createPolicy = jest.fn((_name: string, rules: Record<string, unknown>) => ({
+        createScript: rules['createScript'],
+        createScriptURL: rules['createScriptURL'],
+      }));
+      (globalThis as { trustedTypes?: unknown }).trustedTypes = { createPolicy };
+    });
+
+    it('creates the native policy with the provided name and validators', () => {
+      getTrustedTypesPolicy('my-policy');
+      expect(createPolicy).toHaveBeenCalledTimes(1);
+      const [name, rules] = createPolicy.mock.calls[0]!;
+      expect(name).toBe('my-policy');
+      expect(typeof rules.createScript).toBe('function');
+      expect(typeof rules.createScriptURL).toBe('function');
+    });
+
+    it('memoizes the policy across calls', () => {
+      const a = getTrustedTypesPolicy('nfo');
+      const b = getTrustedTypesPolicy('nfo');
+      expect(createPolicy).toHaveBeenCalledTimes(1);
+      expect(a).toBe(b);
+    });
+  });
+
+  describe('createScript validator', () => {
+    let validator: (input: string) => string;
+
+    beforeEach(() => {
+      const createPolicy = jest.fn((_name: string, rules: Record<string, unknown>) => {
+        validator = rules['createScript'] as (input: string) => string;
+        return {
+          createScript: validator,
+          createScriptURL: rules['createScriptURL'],
+        };
+      });
+      (globalThis as { trustedTypes?: unknown }).trustedTypes = { createPolicy };
+      getTrustedTypesPolicy();
+    });
+
+    it('accepts a valid import map', () => {
+      const json = JSON.stringify({
+        imports: { foo: 'https://x.test/foo.js' },
+        scopes: { 'https://x.test/': { bar: 'https://x.test/bar.js' } },
+      });
+      expect(validator(json)).toBe(json);
+    });
+
+    it('rejects malformed JSON', () => {
+      expect(() => validator('{ not json')).toThrow(TypeError);
+    });
+
+    it('rejects non-object roots', () => {
+      expect(() => validator(JSON.stringify(['imports']))).toThrow(TypeError);
+      expect(() => validator(JSON.stringify('hello'))).toThrow(TypeError);
+      expect(() => validator(JSON.stringify(null))).toThrow(TypeError);
+    });
+
+    it('rejects unexpected keys', () => {
+      expect(() =>
+        validator(JSON.stringify({ imports: {}, malicious: 'payload' }))
+      ).toThrow(/unexpected key "malicious"/);
+    });
+  });
+
+  describe('createScriptURL validator', () => {
+    let validator: (input: string) => string;
+
+    beforeEach(() => {
+      const createPolicy = jest.fn((_name: string, rules: Record<string, unknown>) => {
+        validator = rules['createScriptURL'] as (input: string) => string;
+        return {
+          createScript: rules['createScript'],
+          createScriptURL: validator,
+        };
+      });
+      (globalThis as { trustedTypes?: unknown }).trustedTypes = { createPolicy };
+      getTrustedTypesPolicy();
+    });
+
+    it('accepts http and https URLs', () => {
+      expect(validator('https://example.test/a.js')).toBe('https://example.test/a.js');
+      expect(validator('http://example.test/a.js')).toBe('http://example.test/a.js');
+    });
+
+    it('accepts relative URLs (resolved against the current document)', () => {
+      expect(validator('/a.js')).toBe('/a.js');
+    });
+
+    it('rejects javascript: URLs', () => {
+      expect(() => validator('javascript:alert(1)')).toThrow(/disallowed protocol/);
+    });
+
+    it('rejects data: URLs', () => {
+      expect(() => validator('data:text/javascript,alert(1)')).toThrow(/disallowed protocol/);
+    });
+
+    it('rejects malformed URLs', () => {
+      expect(() => validator('http://[bad')).toThrow(TypeError);
+    });
+  });
+});

--- a/src/lib/4.config/import-map/trusted-types.ts
+++ b/src/lib/4.config/import-map/trusted-types.ts
@@ -1,0 +1,92 @@
+type TTCreateScript = (input: string) => string;
+type TTCreateScriptURL = (input: string) => string;
+
+type TTPolicyRules = {
+  createScript?: TTCreateScript;
+  createScriptURL?: TTCreateScriptURL;
+};
+
+type TTPolicy = {
+  createScript: TTCreateScript;
+  createScriptURL: TTCreateScriptURL;
+};
+
+type TTFactory = {
+  createPolicy: (name: string, rules: TTPolicyRules) => TTPolicy;
+};
+
+export type NFTrustedTypesPolicy = {
+  createScript: (input: string) => string;
+  createScriptURL: (input: string) => string;
+};
+
+const IMPORT_MAP_KEYS = new Set(['imports', 'scopes', 'integrity']);
+
+const validateImportMapJSON = (input: string): string => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch {
+    throw new TypeError('[nf-orchestrator] trusted-types: import map is not valid JSON');
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new TypeError('[nf-orchestrator] trusted-types: import map must be a plain object');
+  }
+  for (const key of Object.keys(parsed as Record<string, unknown>)) {
+    if (!IMPORT_MAP_KEYS.has(key)) {
+      throw new TypeError(`[nf-orchestrator] trusted-types: unexpected key "${key}" in import map`);
+    }
+  }
+  return input;
+};
+
+const validateScriptURL = (input: string): string => {
+  const base = typeof location !== 'undefined' ? location.href : 'http://localhost/';
+  let url: URL;
+  try {
+    url = new URL(input, base);
+  } catch {
+    throw new TypeError(`[nf-orchestrator] trusted-types: invalid script URL "${input}"`);
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new TypeError(
+      `[nf-orchestrator] trusted-types: disallowed protocol "${url.protocol}" for script URL`
+    );
+  }
+  return input;
+};
+
+const passThroughPolicy: NFTrustedTypesPolicy = {
+  createScript: input => input,
+  createScriptURL: input => input,
+};
+
+let cachedPolicy: NFTrustedTypesPolicy | null = null;
+
+export const getTrustedTypesPolicy = (
+  name: string | false = 'nfo'
+): NFTrustedTypesPolicy => {
+  if (name === false) return passThroughPolicy;
+  if (cachedPolicy) return cachedPolicy;
+
+  const factory = (globalThis as { trustedTypes?: TTFactory }).trustedTypes;
+  if (!factory) {
+    cachedPolicy = passThroughPolicy;
+    return cachedPolicy;
+  }
+
+  const native = factory.createPolicy(name, {
+    createScript: validateImportMapJSON,
+    createScriptURL: validateScriptURL,
+  });
+
+  cachedPolicy = {
+    createScript: input => native.createScript(input) as unknown as string,
+    createScriptURL: input => native.createScriptURL(input) as unknown as string,
+  };
+  return cachedPolicy;
+};
+
+export const __resetTrustedTypesPolicyForTests = (): void => {
+  cachedPolicy = null;
+};

--- a/src/lib/4.config/import-map/use-default.ts
+++ b/src/lib/4.config/import-map/use-default.ts
@@ -1,9 +1,15 @@
 import type { ImportMapConfig } from 'lib/2.app/config/import-map.contract';
 import { replaceInDOM } from './replace-in-dom';
+import { getTrustedTypesPolicy } from './trusted-types';
 
-const useDefaultImportMap = (): ImportMapConfig => ({
-  loadModuleFn: url => import(/* @vite-ignore */ url),
-  setImportMapFn: replaceInDOM('importmap'),
+const useDefaultImportMap = (
+  trustedTypesPolicyName: string | false = 'nfo'
+): ImportMapConfig => ({
+  loadModuleFn: url => {
+    const trusted = getTrustedTypesPolicy(trustedTypesPolicyName).createScriptURL(url);
+    return import(/* @vite-ignore */ trusted);
+  },
+  setImportMapFn: replaceInDOM('importmap', trustedTypesPolicyName),
   reloadBrowserFn: () => {
     window.location.reload();
   },

--- a/src/lib/4.config/import-map/use-import-shim.spec.ts
+++ b/src/lib/4.config/import-map/use-import-shim.spec.ts
@@ -1,0 +1,54 @@
+import { useShimImportMap } from './use-import-shim';
+import { __resetTrustedTypesPolicyForTests } from './trusted-types';
+
+declare const global: typeof globalThis;
+
+describe('useShimImportMap', () => {
+  let importShimMock: jest.Mock;
+
+  beforeEach(() => {
+    importShimMock = jest.fn().mockResolvedValue({});
+    (global as unknown as { importShim: unknown }).importShim = importShimMock;
+    __resetTrustedTypesPolicyForTests();
+  });
+
+  afterEach(() => {
+    delete (globalThis as { trustedTypes?: unknown }).trustedTypes;
+    delete (global as unknown as { importShim?: unknown }).importShim;
+    __resetTrustedTypesPolicyForTests();
+  });
+
+  it('passes the URL string to importShim when no Trusted Types factory exists', () => {
+    const config = useShimImportMap();
+
+    config.loadModuleFn('https://example.test/a.js');
+
+    expect(importShimMock).toHaveBeenCalledWith('https://example.test/a.js');
+    expect(typeof importShimMock.mock.calls[0]![0]).toBe('string');
+  });
+
+  it('coerces a TrustedScriptURL returned by the policy to a string before calling importShim', () => {
+    // Real browsers return a TrustedScriptURL object — an opaque wrapper that
+    // exposes its href via toString() but has no .indexOf(). Passing it directly
+    // into importShim() throws "relUrl.indexOf is not a function" inside
+    // es-module-shims (see resolveIfNotPlainOrUrl).
+    const trustedScriptURL = {
+      toString: () => 'https://example.test/a.js',
+    };
+    const createScriptURL = jest.fn(() => trustedScriptURL);
+    (globalThis as { trustedTypes?: unknown }).trustedTypes = {
+      createPolicy: jest.fn(() => ({
+        createScript: (s: string) => s,
+        createScriptURL,
+      })),
+    };
+
+    const config = useShimImportMap();
+    config.loadModuleFn('https://example.test/a.js');
+
+    expect(createScriptURL).toHaveBeenCalledWith('https://example.test/a.js');
+    const arg = importShimMock.mock.calls[0]![0];
+    expect(typeof arg).toBe('string');
+    expect(arg).toBe('https://example.test/a.js');
+  });
+});

--- a/src/lib/4.config/import-map/use-import-shim.ts
+++ b/src/lib/4.config/import-map/use-import-shim.ts
@@ -10,7 +10,7 @@ const useShimImportMap = (
 ): ImportMapConfig => ({
   loadModuleFn: url => {
     const trusted = getTrustedTypesPolicy(trustedTypesPolicyName).createScriptURL(url);
-    return importShim(trusted);
+    return importShim(String(trusted));
   },
   setImportMapFn: replaceInDOM(
     cfg.shimMode ? 'importmap-shim' : 'importmap',

--- a/src/lib/4.config/import-map/use-import-shim.ts
+++ b/src/lib/4.config/import-map/use-import-shim.ts
@@ -1,11 +1,21 @@
 import type { ImportMapConfig } from 'lib/2.app/config/import-map.contract';
 import { replaceInDOM } from './replace-in-dom';
+import { getTrustedTypesPolicy } from './trusted-types';
 
 declare function importShim<T>(url: string): T;
 
-const useShimImportMap = (cfg: { shimMode: boolean } = { shimMode: false }): ImportMapConfig => ({
-  loadModuleFn: url => importShim(url),
-  setImportMapFn: replaceInDOM(cfg.shimMode ? 'importmap-shim' : 'importmap'),
+const useShimImportMap = (
+  cfg: { shimMode: boolean } = { shimMode: false },
+  trustedTypesPolicyName: string | false = 'nfo'
+): ImportMapConfig => ({
+  loadModuleFn: url => {
+    const trusted = getTrustedTypesPolicy(trustedTypesPolicyName).createScriptURL(url);
+    return importShim(trusted);
+  },
+  setImportMapFn: replaceInDOM(
+    cfg.shimMode ? 'importmap-shim' : 'importmap',
+    trustedTypesPolicyName
+  ),
   reloadBrowserFn: () => {
     window.location.reload();
   },

--- a/src/lib/5.di/flows/dynamic-init.factory.ts
+++ b/src/lib/5.di/flows/dynamic-init.factory.ts
@@ -46,9 +46,9 @@ export const createDynamicInitFlow = ({
   const processDynamicRemoteEntry = async (remoteEntry: RemoteEntry) => {
     return flow.updateCache(remoteEntry).then(flow.convertToImportMap).then(flow.commitChanges);
   };
-  const initRemoteEntry: DynamicInitFlow = (remoteEntryUrl, remoteName) =>
+  const initRemoteEntry: DynamicInitFlow = (remoteEntryUrl, remote) =>
     flow
-      .getRemoteEntry(remoteEntryUrl, remoteName)
+      .getRemoteEntry(remoteEntryUrl, remote)
       .then(entry => entry.map(processDynamicRemoteEntry).orElse(Promise.resolve()))
       .then(() => ({
         config,

--- a/src/lib/init-federation.ts
+++ b/src/lib/init-federation.ts
@@ -1,5 +1,6 @@
 import type { LoadRemoteModuleOf, NativeFederationResult } from './init-federation.contract';
 import type { NFOptions } from './2.app/config/config.contract';
+import type { RemoteRef } from './2.app/driver-ports/dynamic-init/flow.contract';
 import { createInitFlow, INIT_FLOW_FACTORY } from './5.di/flows/init.factory';
 import { createDriving } from './5.di/driving.factory';
 import { createConfigHandlers } from './5.di/config.factory';
@@ -44,9 +45,10 @@ const initFederation = (
 
       const initRemoteEntry = async (
         remoteEntryUrl: string,
-        remoteName?: string
-      ): Promise<NativeFederationResult> =>
-        dynamicInitFlow(remoteEntryUrl, remoteName)
+        remote?: RemoteRef
+      ): Promise<NativeFederationResult> => {
+        const remoteName = typeof remote === 'string' ? remote : remote?.name;
+        return dynamicInitFlow(remoteEntryUrl, remote)
           .catch(e => {
             stateDump(`[dynamic-init][${remoteName ?? remoteEntryUrl}] STATE DUMP`);
             if (config.strict.strictRemoteEntry) return Promise.reject(e);
@@ -57,6 +59,7 @@ const initFederation = (
             ...output,
             initRemoteEntry,
           }));
+      };
 
       return {
         ...output,

--- a/src/lib/utils/integrity.spec.ts
+++ b/src/lib/utils/integrity.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment node
+ */
+import { verifyIntegrity } from './integrity';
+
+const encode = (s: string): ArrayBuffer => {
+  const buf = new TextEncoder().encode(s);
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+};
+
+const sriOf = async (algorithm: 'SHA-256' | 'SHA-384' | 'SHA-512', input: string) => {
+  const digest = await crypto.subtle.digest(algorithm, encode(input));
+  const view = new Uint8Array(digest);
+  let bin = '';
+  for (let i = 0; i < view.length; i++) bin += String.fromCharCode(view[i]!);
+  const prefix =
+    algorithm === 'SHA-256' ? 'sha256-' : algorithm === 'SHA-384' ? 'sha384-' : 'sha512-';
+  return prefix + btoa(bin);
+};
+
+describe('verifyIntegrity', () => {
+  it('should resolve when sha384 hash matches', async () => {
+    const payload = '{"hello":"world"}';
+    const expected = await sriOf('SHA-384', payload);
+
+    await expect(verifyIntegrity(encode(payload), expected)).resolves.toBeUndefined();
+  });
+
+  it('should resolve for sha256 and sha512', async () => {
+    const payload = '{"a":1}';
+    const sha256 = await sriOf('SHA-256', payload);
+    const sha512 = await sriOf('SHA-512', payload);
+
+    await expect(verifyIntegrity(encode(payload), sha256)).resolves.toBeUndefined();
+    await expect(verifyIntegrity(encode(payload), sha512)).resolves.toBeUndefined();
+  });
+
+  it('should reject when the hash does not match', async () => {
+    const payload = '{"hello":"world"}';
+    const wrong = 'sha384-' + 'A'.repeat(64);
+
+    await expect(verifyIntegrity(encode(payload), wrong)).rejects.toThrow(/Integrity mismatch/);
+  });
+
+  it('should reject for an unsupported algorithm prefix', async () => {
+    await expect(verifyIntegrity(encode('x'), 'md5-abcdef')).rejects.toThrow(
+      /Unsupported integrity prefix/
+    );
+  });
+});

--- a/src/lib/utils/integrity.ts
+++ b/src/lib/utils/integrity.ts
@@ -1,0 +1,46 @@
+const SUPPORTED_ALGORITHMS = {
+  'sha256-': 'SHA-256',
+  'sha384-': 'SHA-384',
+  'sha512-': 'SHA-512',
+} as const;
+
+type Prefix = keyof typeof SUPPORTED_ALGORITHMS;
+
+const parseIntegrity = (integrity: string): { algorithm: string; expected: string } | null => {
+  for (const prefix of Object.keys(SUPPORTED_ALGORITHMS) as Prefix[]) {
+    if (integrity.startsWith(prefix)) {
+      return { algorithm: SUPPORTED_ALGORITHMS[prefix], expected: integrity };
+    }
+  }
+  return null;
+};
+
+const toBase64 = (bytes: ArrayBuffer): string => {
+  const view = new Uint8Array(bytes);
+  let bin = '';
+  for (let i = 0; i < view.length; i++) bin += String.fromCharCode(view[i]!);
+  return btoa(bin);
+};
+
+export const verifyIntegrity = async (bytes: ArrayBuffer, integrity: string): Promise<void> => {
+  const parsed = parseIntegrity(integrity);
+  if (!parsed) {
+    throw new TypeError(
+      `Unsupported integrity prefix in '${integrity}'. Expected sha256-, sha384-, or sha512-.`
+    );
+  }
+
+  const subtle =
+    typeof crypto !== 'undefined' && crypto.subtle ? crypto.subtle : undefined;
+  if (!subtle) {
+    throw new Error('SubtleCrypto is not available in this environment.');
+  }
+
+  const digest = await subtle.digest(parsed.algorithm, bytes);
+  const actual =
+    integrity.substring(0, integrity.indexOf('-') + 1) + toBase64(digest);
+
+  if (actual !== parsed.expected) {
+    throw new Error(`Integrity mismatch: expected ${parsed.expected}, got ${actual}`);
+  }
+};


### PR DESCRIPTION
This pull request introduces first-class support for Trusted Types and Content Security Policy (CSP) integration in the orchestrator. It ensures that both the injected import map and dynamic imports are routed through a vetted Trusted Types policy, providing structural XSS protection when enabled. The changes include new configuration options, implementation of policy validation, comprehensive documentation, and tests for the new security features.

**Trusted Types & Security Integration:**

* Added a new `trustedTypesPolicyName` option to the import map configuration, allowing users to specify the Trusted Types policy name or disable it entirely. The default is `'nfo'`. [[1]](diffhunk://#diff-0527ca5563628f0e9a8ead6fd9e35519ed926605810102ea61105c17a8fb557fL14-R25) [[2]](diffhunk://#diff-77b3519370ff48f6caf7c316f0ece966f2f0871c40e9381d451d2c5b1c76b40fR54-R65)
* Implemented the Trusted Types policy logic in `trusted-types.ts`, including strict validators for import map JSON and script URLs, a pass-through fallback for unsupported browsers, and memoization for efficiency.
* Updated the default import map handling to wrap both import map content and dynamic import URLs with the Trusted Types policy, and made these behaviors configurable. [[1]](diffhunk://#diff-065dcc141fdd0b7b50082615d850c1ade925632a63aa488362a8572c1d2fc657R3-R12) [[2]](diffhunk://#diff-78b5d4534352cc6225cc424cf0e8eff9b65987a3abf15067b487ff77bf4761c4R3-R18) [[3]](diffhunk://#diff-0592b751ecfd5def4072a4f401f28bbcb914743d40e0fd09e59af77467ee8c44L5-R5)

**Documentation:**

* Added a comprehensive `docs/security.md` explaining how Trusted Types are used, recommended CSP headers, configuration options, and caveats. Linked this new documentation from the main `README.md` and referenced it in `docs/config.md`. [[1]](diffhunk://#diff-2c506cc756a5333f8fb5acb850d443980706602048f9ddb3dc515abacbfbce6aR1-R95) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R129) [[3]](diffhunk://#diff-77b3519370ff48f6caf7c316f0ece966f2f0871c40e9381d451d2c5b1c76b40fR54-R65) [[4]](diffhunk://#diff-77b3519370ff48f6caf7c316f0ece966f2f0871c40e9381d451d2c5b1c76b40fR84-R91)

**Testing:**

* Added and expanded unit tests for Trusted Types logic, including validation, pass-through behavior, and policy memoization. Also updated tests for import map DOM injection to cover Trusted Types scenarios. [[1]](diffhunk://#diff-ef4371827296b4f5b87edba0514249bef796d2a88118ff7d11d148525b8ff4f3R1-R148) [[2]](diffhunk://#diff-550af0cf2f5d2ce2e2f98f8cd73e47dc8b1ff12bfbfd7a5b64d22630acd6b7e4R3-R21) [[3]](diffhunk://#diff-550af0cf2f5d2ce2e2f98f8cd73e47dc8b1ff12bfbfd7a5b64d22630acd6b7e4R95-R115)

These changes provide robust, configurable security for import map and remote module loading, and comprehensive documentation and tests to support adoption.