### PR TITLE
chore: Added support for integrity tags in manifest

### DIFF
--- a/src/lib/1.domain/remote-entry/manifest.contract.ts
+++ b/src/lib/1.domain/remote-entry/manifest.contract.ts
@@ -4,4 +4,4 @@ export type RemoteEntryUrl = string;
 
 export type RemoteEntryDescriptor = RemoteEntryUrl | { url: RemoteEntryUrl; integrity?: string };
 
-export type Manifest = Record<RemoteName, RemoteEntryDescriptor>;
+export type FederationManifest = Record<RemoteName, RemoteEntryDescriptor>;

--- a/src/lib/2.app/driver-ports/init/flow.contract.ts
+++ b/src/lib/2.app/driver-ports/init/flow.contract.ts
@@ -1,8 +1,8 @@
-import type { Manifest } from 'lib/1.domain';
+import type { FederationManifest } from 'lib/1.domain';
 import type { LoadRemoteModule } from 'lib/init-federation.contract';
 
 export type InitResult = {
   loadRemoteModule: LoadRemoteModule;
 };
 
-export type InitFlow = (remotesOrManifestUrl: string | Manifest) => Promise<InitResult>;
+export type InitFlow = (remotesOrManifestUrl: string | FederationManifest) => Promise<InitResult>;

--- a/src/lib/2.app/driver-ports/init/for-getting-remote-entries.port.ts
+++ b/src/lib/2.app/driver-ports/init/for-getting-remote-entries.port.ts
@@ -1,6 +1,6 @@
 import type { RemoteEntry } from 'lib/1.domain/remote-entry/remote-entry.contract';
-import type { Manifest } from 'lib/1.domain/remote-entry/manifest.contract';
+import type { FederationManifest } from 'lib/1.domain/remote-entry/manifest.contract';
 
 export type ForGettingRemoteEntries = (
-  remotesOrManifestUrl: string | Manifest
+  remotesOrManifestUrl: string | FederationManifest
 ) => Promise<RemoteEntry[]>;

--- a/src/lib/2.app/driving-ports/for-providing-manifest.port.ts
+++ b/src/lib/2.app/driving-ports/for-providing-manifest.port.ts
@@ -1,8 +1,8 @@
-import type { Manifest } from 'lib/1.domain/remote-entry/manifest.contract';
+import type { FederationManifest } from 'lib/1.domain/remote-entry/manifest.contract';
 
 export type ForProvidingManifest = {
   provide: (
-    remotesOrManifestUrl: Manifest | string,
+    remotesOrManifestUrl: FederationManifest | string,
     opts?: { integrity?: string }
-  ) => Promise<Manifest>;
+  ) => Promise<FederationManifest>;
 };

--- a/src/lib/2.app/flows/init/get-remote-entries.ts
+++ b/src/lib/2.app/flows/init/get-remote-entries.ts
@@ -1,6 +1,6 @@
 import type { RemoteEntry } from 'lib/1.domain/remote-entry/remote-entry.contract';
 import type {
-  Manifest,
+  FederationManifest,
   RemoteEntryDescriptor,
   RemoteEntryUrl,
 } from 'lib/1.domain/remote-entry/manifest.contract';
@@ -49,7 +49,7 @@ export function createGetRemoteEntries(
       .then(checkForSSE);
   };
 
-  function addHostRemoteEntry(manifest: Manifest): Manifest {
+  function addHostRemoteEntry(manifest: FederationManifest): FederationManifest {
     if (!config.hostRemoteEntry) return manifest;
 
     const { name, url, cacheTag, integrity } = config.hostRemoteEntry;
@@ -68,7 +68,7 @@ export function createGetRemoteEntries(
     return typeof descriptor === 'string' ? { url: descriptor } : descriptor;
   }
 
-  async function fetchRemoteEntries(manifest: Manifest): Promise<(RemoteEntry | false)[]> {
+  async function fetchRemoteEntries(manifest: FederationManifest): Promise<(RemoteEntry | false)[]> {
     const fetchPromises = Object.entries(manifest).map(([remoteName, descriptor]) =>
       fetchRemoteEntry(remoteName, descriptor)
     );

--- a/src/lib/3.adapters/http/manifest-provider.spec.ts
+++ b/src/lib/3.adapters/http/manifest-provider.spec.ts
@@ -1,12 +1,12 @@
 import { createManifestProvider } from './manifest-provider';
-import { Manifest } from 'lib/1.domain/remote-entry/manifest.contract';
+import { FederationManifest } from 'lib/1.domain/remote-entry/manifest.contract';
 import { ForProvidingManifest } from 'lib/2.app/driving-ports/for-providing-manifest.port';
 import { NFError } from 'lib/native-federation.error';
 
 describe('createManifestProvider', () => {
   let manifestProvider: ForProvidingManifest;
 
-  const mockFetchAPI = (response: Manifest) => {
+  const mockFetchAPI = (response: FederationManifest) => {
     global.fetch = jest.fn(url => {
       if (url === 'http://my.service/manifest.json')
         return Promise.resolve({

--- a/src/lib/3.adapters/http/manifest-provider.ts
+++ b/src/lib/3.adapters/http/manifest-provider.ts
@@ -1,4 +1,4 @@
-import type { Manifest } from 'lib/1.domain';
+import type { FederationManifest } from 'lib/1.domain';
 import type { ForProvidingManifest } from 'lib/2.app/driving-ports/for-providing-manifest.port';
 import { NFError } from 'lib/native-federation.error';
 import { verifyIntegrity } from 'lib/utils/integrity';
@@ -17,16 +17,16 @@ const createManifestProvider = (): ForProvidingManifest => {
 
   return {
     provide: async function (
-      remotesOrManifestUrl: string | Manifest,
+      remotesOrManifestUrl: string | FederationManifest,
       opts: { integrity?: string } = {}
     ) {
       if (typeof remotesOrManifestUrl !== 'string') return Promise.resolve(remotesOrManifestUrl);
 
-      const parse = async (response: Response): Promise<Manifest> => {
-        if (!opts.integrity) return response.json() as Promise<Manifest>;
+      const parse = async (response: Response): Promise<FederationManifest> => {
+        if (!opts.integrity) return response.json() as Promise<FederationManifest>;
         const bytes = await response.arrayBuffer();
         await verifyIntegrity(bytes, opts.integrity);
-        return JSON.parse(new TextDecoder().decode(bytes)) as Manifest;
+        return JSON.parse(new TextDecoder().decode(bytes)) as FederationManifest;
       };
 
       return fetch(remotesOrManifestUrl)

--- a/src/lib/6.mocks/adapters/manifest-provider.mock.ts
+++ b/src/lib/6.mocks/adapters/manifest-provider.mock.ts
@@ -1,9 +1,9 @@
 import { ForProvidingManifest } from 'lib/2.app/driving-ports/for-providing-manifest.port';
 import { mockManifest } from '../domain/manifest.mock';
-import { Manifest } from 'lib/1.domain';
+import { FederationManifest } from 'lib/1.domain';
 
 export const mockManifestProvider = (): jest.Mocked<ForProvidingManifest> => ({
-  provide: jest.fn((manifest: string | Manifest) => {
+  provide: jest.fn((manifest: string | FederationManifest) => {
     return Promise.resolve(typeof manifest === 'string' ? mockManifest() : manifest);
   }),
 });

--- a/src/lib/6.mocks/domain/manifest.mock.ts
+++ b/src/lib/6.mocks/domain/manifest.mock.ts
@@ -1,7 +1,7 @@
-import { Manifest } from 'lib/1.domain';
+import { FederationManifest } from 'lib/1.domain';
 import { mockScopeUrl_MFE1, mockScopeUrl_MFE2 } from './scope-url.mock';
 
-export const mockManifest = (): Manifest => ({
+export const mockManifest = (): FederationManifest => ({
   'team/mfe1': `${mockScopeUrl_MFE1()}remoteEntry.json`,
   'team/mfe2': `${mockScopeUrl_MFE2()}remoteEntry.json`,
 });

--- a/src/lib/init-federation.ts
+++ b/src/lib/init-federation.ts
@@ -1,6 +1,7 @@
 import type { LoadRemoteModuleOf, NativeFederationResult } from './init-federation.contract';
 import type { NFOptions } from './2.app/config/config.contract';
 import type { RemoteRef } from './2.app/driver-ports/dynamic-init/flow.contract';
+import type { FederationManifest } from './1.domain';
 import { createInitFlow, INIT_FLOW_FACTORY } from './5.di/flows/init.factory';
 import { createDriving } from './5.di/driving.factory';
 import { createConfigHandlers } from './5.di/config.factory';
@@ -10,7 +11,7 @@ import {
 } from './5.di/flows/dynamic-init.factory';
 
 const initFederation = (
-  remotesOrManifestUrl: string | Record<string, string>,
+  remotesOrManifestUrl: string | FederationManifest,
   options: NFOptions = {}
 ): Promise<NativeFederationResult> => {
   const { adapters, config } = createDriving(createConfigHandlers(options));


### PR DESCRIPTION
This pull request standardizes the naming of the manifest type used for remote entries across the codebase. The previous `Manifest` type has been renamed to `FederationManifest`, and all relevant imports, function parameters, and type annotations have been updated accordingly. This change improves clarity and consistency in the codebase, making it easier to understand and maintain.

**Manifest type renaming and propagation:**

* Renamed the `Manifest` type to `FederationManifest` in `manifest.contract.ts` and updated all imports and usages throughout the codebase to use the new name. [[1]](diffhunk://#diff-5b9fc67850b43f60b528ce52b3d5554d07ded1315e8a6b6c64076bb81565b007L7-R7) [[2]](diffhunk://#diff-b613cf9cc9adfac3cfcf4fca4728c83cb1533741e96b35964a85f4ec6e885b04L1-R8) [[3]](diffhunk://#diff-c310fe45e84f27b651f943ea4e916eef5f1ce3f4c504fbb6472ab7619d15da9dL2-R5) [[4]](diffhunk://#diff-3ba0a504380d411a56129c019e841040267368e92ee68ee4ce61df01fcd9c8d4L1-R7) [[5]](diffhunk://#diff-0ad6f97b02d2a6a6b7211068501d14eb7b4e7bc84a845daf77291c0c70bc395cL3-R3) [[6]](diffhunk://#diff-6c9b9e09ab110c11b40d792e56f9dccb9aa07db40cd8636cd6d90f59b2e45139L2-R9) [[7]](diffhunk://#diff-04aac4db1dca1229e2bdf547f651547e5f16a06378f30ff5d2f007ee31289035L1-R1) [[8]](diffhunk://#diff-33476d2571658c7c809c2a9feb83c6d7e05bcb12914242fb9d4e822c6bb3b992L3-R6) [[9]](diffhunk://#diff-f3cefa5d8578ba4b937bab4638a7d61eb56ddee2e0e50457be947f7061742a44L1-R4) [[10]](diffhunk://#diff-028cb96bd2d2f0b7366d8baf034727bac904e841815fe47ca9854f2fa07c3dddR4)

**Function and parameter updates:**

* Updated all function signatures, parameters, and return types to use `FederationManifest` instead of `Manifest`, including in initialization flows, manifest providers, and mocks. [[1]](diffhunk://#diff-b613cf9cc9adfac3cfcf4fca4728c83cb1533741e96b35964a85f4ec6e885b04L1-R8) [[2]](diffhunk://#diff-c310fe45e84f27b651f943ea4e916eef5f1ce3f4c504fbb6472ab7619d15da9dL2-R5) [[3]](diffhunk://#diff-3ba0a504380d411a56129c019e841040267368e92ee68ee4ce61df01fcd9c8d4L1-R7) [[4]](diffhunk://#diff-0ad6f97b02d2a6a6b7211068501d14eb7b4e7bc84a845daf77291c0c70bc395cL52-R52) [[5]](diffhunk://#diff-0ad6f97b02d2a6a6b7211068501d14eb7b4e7bc84a845daf77291c0c70bc395cL71-R71) [[6]](diffhunk://#diff-6c9b9e09ab110c11b40d792e56f9dccb9aa07db40cd8636cd6d90f59b2e45139L2-R9) [[7]](diffhunk://#diff-04aac4db1dca1229e2bdf547f651547e5f16a06378f30ff5d2f007ee31289035L20-R29) [[8]](diffhunk://#diff-33476d2571658c7c809c2a9feb83c6d7e05bcb12914242fb9d4e822c6bb3b992L3-R6) [[9]](diffhunk://#diff-f3cefa5d8578ba4b937bab4638a7d61eb56ddee2e0e50457be947f7061742a44L1-R4) [[10]](diffhunk://#diff-028cb96bd2d2f0b7366d8baf034727bac904e841815fe47ca9854f2fa07c3dddL13-R14)

These changes ensure the manifest type is clearly named and consistently referenced, reducing ambiguity and potential errors when working with remote entry manifests.