### PR TITLE
chore: Added dependency-bridge feature to node orchestrator

### DIFF
--- a/docs/node.md
+++ b/docs/node.md
@@ -168,6 +168,64 @@ The import map can be updated at any time after the initial install — e.g. whe
 you add a new remote via `initRemoteEntry(...)` — and the loader picks up the
 new map on the next resolution.
 
+## Sharing the host's loaded instances (dev)
+
+In development the host process often runs from its own `node_modules` — its
+`@angular/core` is already loaded as a `file://…` module, outside the federation
+import map. Remotes, meanwhile, resolve `@angular/core` through the import map to
+whatever their `remoteEntry.json` declares. That's **two copies of the framework
+in one process**, which breaks singletons (Angular DI, reflection metadata, …).
+
+The `hostInstances` option bridges that gap — it takes three forms:
+
+**Auto-derive from the host remoteEntry (recommended).** Pass `'all'` and the
+orchestrator reads the host's shared singletons straight out of its
+`remoteEntry.json`, imports each in the host realm, and bridges them. Nothing to
+list by hand, and nothing to forget:
+
+```js
+await initNodeFederation('./dist/browser/federation.manifest.json', {
+  hostRemoteEntry: './dist/browser/remoteEntry.json',
+  hostInstances: 'all',
+});
+```
+
+**Auto-derive, filtered.** Restrict it to the specifiers you actually want to
+bridge with `include` / `exclude` (exact or prefix match):
+
+```js
+hostInstances: { include: ['@angular/', 'rxjs', 'zone.js', 'tslib'] },
+// or
+hostInstances: { exclude: ['some-dep-you-want-scoped'] },
+```
+
+**Explicit map.** Hand over the namespace objects yourself — useful when an
+instance comes from somewhere other than a plain `import`:
+
+```js
+hostInstances: {
+  '@angular/core': await import('@angular/core'),
+  '@angular/common': await import('@angular/common'),
+},
+```
+
+How it works: each namespace is published on `globalThis.__NF_HOST_INSTANCES__`,
+and the loader synthesizes a tiny re-export module (`nf-host:<specifier>`) for
+each bridged specifier. A bridged specifier **wins over the import map** —
+`initNodeFederation` waits for the loader to acknowledge the bridge before it
+resolves any remote import. A specifier that can't be loaded in auto mode is
+skipped with a warning rather than aborting init.
+
+> **This is an escape hatch, not part of the sharing model.** `hostInstances`
+> bypasses the version resolver, the import map, and integrity checks entirely,
+> and hands over **value snapshots** (not live bindings). That's fine for
+> packages whose exports are stable references (Angular's classes/functions),
+> not for packages that reassign their exports after init.
+
+Omit it in production: with no `hostInstances`, nothing is published and the
+loader never routes to the bridge — resolution stays import-map only, with full
+version resolution and integrity verification.
+
 ## What is _not_ on the Node entry
 
 These are deliberately omitted because they make no sense server-side:

--- a/src/lib/3.adapters/node/node-loader.client.spec.ts
+++ b/src/lib/3.adapters/node/node-loader.client.spec.ts
@@ -104,15 +104,15 @@ describe('node-loader.client', () => {
     await expect(pending).resolves.toBeUndefined();
   });
 
-  it('posts the share scope on setShareScope and resolves when the loader acks', async () => {
+  it('posts the host instances on setHostInstances and resolves when the loader acks', async () => {
     const client = getNodeLoaderClient();
     const keys = { '@angular/core': ['Component'] };
 
-    const pending = client.setShareScope(keys);
+    const pending = client.setHostInstances(keys);
     await flushMicrotasks();
 
     expect(mockPorts[0]!.port1.postMessage).toHaveBeenCalledWith({
-      type: 'set-share-scope',
+      type: 'set-host-instances',
       keys,
     });
 
@@ -123,47 +123,72 @@ describe('node-loader.client', () => {
     await flushMicrotasks();
     expect(resolved).toBe(false);
 
-    mockPorts[0]!.port1.mockEmit({ type: 'share-scope-applied' });
+    mockPorts[0]!.port1.mockEmit({ type: 'host-instances-applied' });
     await expect(pending).resolves.toBeUndefined();
   });
 
-  it('serializes setShareScope behind a pending setMap and matches acks by type', async () => {
+  it('serializes setHostInstances behind a pending setMap and matches acks by type', async () => {
     const client = getNodeLoaderClient();
     const port1 = mockPorts[0]!.port1;
 
     const pMap = client.setMap({ imports: { a: '/a.mjs' } });
-    const pScope = client.setShareScope({ pkg: ['x'] });
+    const pHost = client.setHostInstances({ pkg: ['x'] });
     await flushMicrotasks();
 
-    // Only set-import-map posted so far; set-share-scope waits its turn.
+    // Only set-import-map posted so far; set-host-instances waits its turn.
     expect(port1.postMessage).toHaveBeenCalledTimes(1);
     expect(port1.postMessage).toHaveBeenNthCalledWith(1, {
       type: 'set-import-map',
       map: { imports: { a: '/a.mjs' } },
     });
 
-    let scopeResolved = false;
-    pScope.then(() => {
-      scopeResolved = true;
+    let hostResolved = false;
+    pHost.then(() => {
+      hostResolved = true;
     });
 
-    // A share-scope ack must NOT resolve the still-pending setMap.
-    port1.mockEmit({ type: 'share-scope-applied' });
+    // A host-instances ack must NOT resolve the still-pending setMap.
+    port1.mockEmit({ type: 'host-instances-applied' });
     await flushMicrotasks();
-    expect(scopeResolved).toBe(false);
+    expect(hostResolved).toBe(false);
 
-    // The correct ack releases setMap and lets set-share-scope post.
+    // The correct ack releases setMap and lets set-host-instances post.
     port1.mockEmit({ type: 'import-map-applied' });
     await pMap;
     await flushMicrotasks();
-    expect(scopeResolved).toBe(false);
+    expect(hostResolved).toBe(false);
     expect(port1.postMessage).toHaveBeenNthCalledWith(2, {
-      type: 'set-share-scope',
+      type: 'set-host-instances',
       keys: { pkg: ['x'] },
     });
 
-    port1.mockEmit({ type: 'share-scope-applied' });
-    await expect(pScope).resolves.toBeUndefined();
+    port1.mockEmit({ type: 'host-instances-applied' });
+    await expect(pHost).resolves.toBeUndefined();
+  });
+
+  it('strips bridged specifiers from the import map it posts', async () => {
+    const client = getNodeLoaderClient();
+    const port1 = mockPorts[0]!.port1;
+
+    client.setHostInstances({ '@angular/core': ['Component'] });
+    await flushMicrotasks();
+    port1.mockEmit({ type: 'host-instances-applied' });
+    await flushMicrotasks();
+
+    client.setMap({
+      imports: { '@angular/core': '/ng.mjs', '@angular/core/': '/ng/', foo: '/foo.mjs' },
+      scopes: { '/a/': { '@angular/core': '/scoped-ng.mjs', bar: '/bar.mjs' } },
+    });
+    await flushMicrotasks();
+
+    expect(port1.postMessage).toHaveBeenNthCalledWith(2, {
+      type: 'set-import-map',
+      map: {
+        // Exact bridged specifier dropped; trailing-slash + others kept.
+        imports: { '@angular/core/': '/ng/', foo: '/foo.mjs' },
+        scopes: { '/a/': { bar: '/bar.mjs' } },
+      },
+    });
   });
 
   it('ignores messages of other types until the right ack arrives', async () => {

--- a/src/lib/3.adapters/node/node-loader.client.spec.ts
+++ b/src/lib/3.adapters/node/node-loader.client.spec.ts
@@ -104,6 +104,68 @@ describe('node-loader.client', () => {
     await expect(pending).resolves.toBeUndefined();
   });
 
+  it('posts the share scope on setShareScope and resolves when the loader acks', async () => {
+    const client = getNodeLoaderClient();
+    const keys = { '@angular/core': ['Component'] };
+
+    const pending = client.setShareScope(keys);
+    await flushMicrotasks();
+
+    expect(mockPorts[0]!.port1.postMessage).toHaveBeenCalledWith({
+      type: 'set-share-scope',
+      keys,
+    });
+
+    let resolved = false;
+    pending.then(() => {
+      resolved = true;
+    });
+    await flushMicrotasks();
+    expect(resolved).toBe(false);
+
+    mockPorts[0]!.port1.mockEmit({ type: 'share-scope-applied' });
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it('serializes setShareScope behind a pending setMap and matches acks by type', async () => {
+    const client = getNodeLoaderClient();
+    const port1 = mockPorts[0]!.port1;
+
+    const pMap = client.setMap({ imports: { a: '/a.mjs' } });
+    const pScope = client.setShareScope({ pkg: ['x'] });
+    await flushMicrotasks();
+
+    // Only set-import-map posted so far; set-share-scope waits its turn.
+    expect(port1.postMessage).toHaveBeenCalledTimes(1);
+    expect(port1.postMessage).toHaveBeenNthCalledWith(1, {
+      type: 'set-import-map',
+      map: { imports: { a: '/a.mjs' } },
+    });
+
+    let scopeResolved = false;
+    pScope.then(() => {
+      scopeResolved = true;
+    });
+
+    // A share-scope ack must NOT resolve the still-pending setMap.
+    port1.mockEmit({ type: 'share-scope-applied' });
+    await flushMicrotasks();
+    expect(scopeResolved).toBe(false);
+
+    // The correct ack releases setMap and lets set-share-scope post.
+    port1.mockEmit({ type: 'import-map-applied' });
+    await pMap;
+    await flushMicrotasks();
+    expect(scopeResolved).toBe(false);
+    expect(port1.postMessage).toHaveBeenNthCalledWith(2, {
+      type: 'set-share-scope',
+      keys: { pkg: ['x'] },
+    });
+
+    port1.mockEmit({ type: 'share-scope-applied' });
+    await expect(pScope).resolves.toBeUndefined();
+  });
+
   it('ignores messages of other types until the right ack arrives', async () => {
     const client = getNodeLoaderClient();
     const pending = client.setMap({ imports: {} });

--- a/src/lib/3.adapters/node/node-loader.client.ts
+++ b/src/lib/3.adapters/node/node-loader.client.ts
@@ -3,11 +3,17 @@ import { MessageChannel } from 'node:worker_threads';
 import type { ImportMap } from 'lib/1.domain';
 import { getLoaderUrl } from './loader-url';
 
-type IncomingMessage = { type: 'import-map-applied' };
-type OutgoingMessage = { type: 'set-import-map'; map: ImportMap };
+/** Per-specifier list of export names to bridge from the host's share scope. */
+export type ShareScopeKeys = Record<string, string[]>;
+
+type IncomingMessage = { type: 'import-map-applied' } | { type: 'share-scope-applied' };
+type OutgoingMessage =
+  | { type: 'set-import-map'; map: ImportMap }
+  | { type: 'set-share-scope'; keys: ShareScopeKeys };
 
 export type NodeLoaderClient = {
   setMap: (map: ImportMap) => Promise<void>;
+  setShareScope: (keys: ShareScopeKeys) => Promise<void>;
   ready: () => Promise<void>;
 };
 
@@ -27,7 +33,10 @@ const createClient = (): NodeLoaderClient => {
 
   let pending: Promise<void> = Promise.resolve();
 
-  const postAndAwaitAck = (map: ImportMap): Promise<void> =>
+  const postAndAwaitAck = (
+    message: OutgoingMessage,
+    ackType: IncomingMessage['type']
+  ): Promise<void> =>
     new Promise<void>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | null = null;
       const cleanup = (): void => {
@@ -35,7 +44,7 @@ const createClient = (): NodeLoaderClient => {
         if (timer !== null) clearTimeout(timer);
       };
       const onMessage = (msg: IncomingMessage): void => {
-        if (msg?.type === 'import-map-applied') {
+        if (msg?.type === ackType) {
           cleanup();
           resolve();
         }
@@ -45,28 +54,36 @@ const createClient = (): NodeLoaderClient => {
         cleanup();
         reject(
           new Error(
-            `node-loader.client: loader did not acknowledge set-import-map within ${NODE_LOADER_CLIENT_ACK_TIMEOUT_MS}ms`
+            `node-loader.client: loader did not acknowledge ${message.type} within ${NODE_LOADER_CLIENT_ACK_TIMEOUT_MS}ms`
           )
         );
       }, NODE_LOADER_CLIENT_ACK_TIMEOUT_MS);
       (timer as { unref?: () => void }).unref?.();
       try {
-        const outgoing: OutgoingMessage = { type: 'set-import-map', map };
-        port1.postMessage(outgoing);
+        port1.postMessage(message);
       } catch (err) {
         cleanup();
         reject(err);
       }
     });
 
-  const setMap = (map: ImportMap): Promise<void> => {
-    const next = pending.catch(() => undefined).then(() => postAndAwaitAck(map));
+  // Serialize every post on a single chain so set-import-map and
+  // set-share-scope can never race each other on the loader thread.
+  const enqueue = (message: OutgoingMessage, ackType: IncomingMessage['type']): Promise<void> => {
+    const next = pending.catch(() => undefined).then(() => postAndAwaitAck(message, ackType));
     pending = next;
     return next;
   };
 
+  const setMap = (map: ImportMap): Promise<void> =>
+    enqueue({ type: 'set-import-map', map }, 'import-map-applied');
+
+  const setShareScope = (keys: ShareScopeKeys): Promise<void> =>
+    enqueue({ type: 'set-share-scope', keys }, 'share-scope-applied');
+
   return {
     setMap,
+    setShareScope,
     ready: () => pending,
   };
 };

--- a/src/lib/3.adapters/node/node-loader.client.ts
+++ b/src/lib/3.adapters/node/node-loader.client.ts
@@ -3,17 +3,17 @@ import { MessageChannel } from 'node:worker_threads';
 import type { ImportMap } from 'lib/1.domain';
 import { getLoaderUrl } from './loader-url';
 
-/** Per-specifier list of export names to bridge from the host's share scope. */
-export type ShareScopeKeys = Record<string, string[]>;
+/** Per-specifier list of export names to bridge from the host's instances. */
+export type HostInstanceKeys = Record<string, string[]>;
 
-type IncomingMessage = { type: 'import-map-applied' } | { type: 'share-scope-applied' };
+type IncomingMessage = { type: 'import-map-applied' } | { type: 'host-instances-applied' };
 type OutgoingMessage =
   | { type: 'set-import-map'; map: ImportMap }
-  | { type: 'set-share-scope'; keys: ShareScopeKeys };
+  | { type: 'set-host-instances'; keys: HostInstanceKeys };
 
 export type NodeLoaderClient = {
   setMap: (map: ImportMap) => Promise<void>;
-  setShareScope: (keys: ShareScopeKeys) => Promise<void>;
+  setHostInstances: (keys: HostInstanceKeys) => Promise<void>;
   ready: () => Promise<void>;
 };
 
@@ -32,6 +32,19 @@ const createClient = (): NodeLoaderClient => {
   port1.unref();
 
   let pending: Promise<void> = Promise.resolve();
+
+  // Specifiers bridged to host instances. The loader resolves these ahead of
+  // the import map, so we strip them from the map we post — no dead entries.
+  const bridged = new Set<string>();
+  const omitBridged = (map: ImportMap): ImportMap => {
+    if (bridged.size === 0) return map;
+    const drop = (imports: ImportMap['imports']): ImportMap['imports'] =>
+      Object.fromEntries(Object.entries(imports).filter(([specifier]) => !bridged.has(specifier)));
+    const scopes = map.scopes
+      ? Object.fromEntries(Object.entries(map.scopes).map(([scope, imports]) => [scope, drop(imports)]))
+      : map.scopes;
+    return { ...map, imports: drop(map.imports), ...(scopes ? { scopes } : {}) };
+  };
 
   const postAndAwaitAck = (
     message: OutgoingMessage,
@@ -68,7 +81,7 @@ const createClient = (): NodeLoaderClient => {
     });
 
   // Serialize every post on a single chain so set-import-map and
-  // set-share-scope can never race each other on the loader thread.
+  // set-host-instances can never race each other on the loader thread.
   const enqueue = (message: OutgoingMessage, ackType: IncomingMessage['type']): Promise<void> => {
     const next = pending.catch(() => undefined).then(() => postAndAwaitAck(message, ackType));
     pending = next;
@@ -76,14 +89,16 @@ const createClient = (): NodeLoaderClient => {
   };
 
   const setMap = (map: ImportMap): Promise<void> =>
-    enqueue({ type: 'set-import-map', map }, 'import-map-applied');
+    enqueue({ type: 'set-import-map', map: omitBridged(map) }, 'import-map-applied');
 
-  const setShareScope = (keys: ShareScopeKeys): Promise<void> =>
-    enqueue({ type: 'set-share-scope', keys }, 'share-scope-applied');
+  const setHostInstances = (keys: HostInstanceKeys): Promise<void> => {
+    Object.keys(keys).forEach(specifier => bridged.add(specifier));
+    return enqueue({ type: 'set-host-instances', keys }, 'host-instances-applied');
+  };
 
   return {
     setMap,
-    setShareScope,
+    setHostInstances,
     ready: () => pending,
   };
 };

--- a/src/lib/4.config/import-map/resolve-host-instances.spec.ts
+++ b/src/lib/4.config/import-map/resolve-host-instances.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ */
+import type { RemoteEntry, SharedInfo } from 'lib/1.domain';
+import type { LogHandler } from 'lib/2.app/config/log.contract';
+import type { ForProvidingRemoteEntries } from 'lib/2.app/driving-ports/for-providing-remote-entries.port';
+import { resolveHostInstances } from './resolve-host-instances';
+
+const shared = (packageName: string, singleton: boolean): SharedInfo =>
+  ({ packageName, singleton, outFileName: `${packageName}.js`, requiredVersion: '*' }) as SharedInfo;
+
+const makeDeps = (
+  sharedInfos: SharedInfo[],
+  hostRemoteEntry: Parameters<typeof resolveHostInstances>[1]['hostRemoteEntry'] = './remoteEntry.json'
+) => {
+  const provide = jest.fn(
+    async (url: string): Promise<RemoteEntry> => ({ url, shared: sharedInfos }) as RemoteEntry
+  );
+  const log = {
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    level: 'debug',
+  } as unknown as LogHandler;
+  return {
+    provide,
+    log,
+    deps: {
+      remoteEntryProvider: { provide } as ForProvidingRemoteEntries,
+      hostRemoteEntry,
+      log,
+    },
+  };
+};
+
+describe('resolveHostInstances', () => {
+  it('returns undefined when no option is given', async () => {
+    const { deps } = makeDeps([]);
+    await expect(resolveHostInstances(undefined, deps)).resolves.toBeUndefined();
+  });
+
+  it('passes an explicit map through unchanged, without touching the remoteEntry', async () => {
+    const ns = { Component: class {} };
+    const { deps, provide } = makeDeps([]);
+
+    const result = await resolveHostInstances({ '@angular/core': ns }, deps);
+
+    expect(result).toEqual({ '@angular/core': ns });
+    expect(provide).not.toHaveBeenCalled();
+  });
+
+  it('in auto mode, derives every shared singleton and imports each in the host realm', async () => {
+    const core = { Component: 1 };
+    const common = { NgIf: 1 };
+    const { deps } = makeDeps([
+      shared('@angular/core', true),
+      shared('@angular/common', true),
+      shared('only-scoped', false),
+    ]);
+    const load = jest.fn(async (s: string) => ({ '@angular/core': core, '@angular/common': common })[s]!);
+
+    const result = await resolveHostInstances({ load }, deps);
+
+    expect(result).toEqual({ '@angular/core': core, '@angular/common': common });
+    expect(load).not.toHaveBeenCalledWith('only-scoped');
+  });
+
+  it('include filters by exact or prefix match', async () => {
+    const { deps } = makeDeps([
+      shared('@angular/core', true),
+      shared('@angular/common', true),
+      shared('rxjs', true),
+      shared('lodash', true),
+    ]);
+    const load = jest.fn(async (s: string) => ({ name: s }));
+
+    const result = await resolveHostInstances({ include: ['@angular/', 'rxjs'], load }, deps);
+
+    expect(Object.keys(result!).sort()).toEqual(['@angular/common', '@angular/core', 'rxjs']);
+    expect(result!['lodash']).toBeUndefined();
+  });
+
+  it('exclude drops matches', async () => {
+    const { deps } = makeDeps([shared('@angular/core', true), shared('zone.js', true)]);
+    const load = jest.fn(async (s: string) => ({ name: s }));
+
+    const result = await resolveHostInstances({ exclude: ['zone.js'], load }, deps);
+
+    expect(Object.keys(result!)).toEqual(['@angular/core']);
+  });
+
+  it('deduplicates repeated package names', async () => {
+    const { deps } = makeDeps([shared('@angular/core', true), shared('@angular/core', true)]);
+    const load = jest.fn(async (s: string) => ({ name: s }));
+
+    const result = await resolveHostInstances({ load }, deps);
+
+    expect(Object.keys(result!)).toEqual(['@angular/core']);
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips a specifier that fails to load and warns, keeping the rest', async () => {
+    const { deps, log } = makeDeps([shared('@angular/core', true), shared('broken', true)]);
+    const load = jest.fn(async (s: string) => {
+      if (s === 'broken') throw new Error('cannot resolve');
+      return { name: s };
+    });
+
+    const result = await resolveHostInstances({ load }, deps);
+
+    expect(Object.keys(result!)).toEqual(['@angular/core']);
+    expect(log.warn).toHaveBeenCalledWith(
+      0,
+      expect.stringContaining("could not load 'broken'")
+    );
+  });
+
+  it('warns and returns undefined when auto mode has no hostRemoteEntry', async () => {
+    const { deps, log, provide } = makeDeps([], false);
+
+    const result = await resolveHostInstances('all', deps);
+
+    expect(result).toBeUndefined();
+    expect(provide).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(0, expect.stringContaining('needs a hostRemoteEntry'));
+  });
+
+  it('passes the host remoteEntry integrity through to the provider', async () => {
+    const { deps, provide } = makeDeps([shared('@angular/core', true)], {
+      url: 'file:///remoteEntry.json',
+      integrity: 'sha384-abc',
+    });
+    const load = jest.fn(async (s: string) => ({ name: s }));
+
+    await resolveHostInstances({ load }, deps);
+
+    expect(provide).toHaveBeenCalledWith('file:///remoteEntry.json', { integrity: 'sha384-abc' });
+  });
+});

--- a/src/lib/4.config/import-map/resolve-host-instances.ts
+++ b/src/lib/4.config/import-map/resolve-host-instances.ts
@@ -1,0 +1,108 @@
+import type { HostOptions } from 'lib/2.app/config/host.contract';
+import type { LogHandler } from 'lib/2.app/config/log.contract';
+import type { ForProvidingRemoteEntries } from 'lib/2.app/driving-ports/for-providing-remote-entries.port';
+
+/** Specifier → module namespace object to bridge into remotes (the host's own instances). */
+export type HostInstanceMap = Record<string, object>;
+
+/**
+ * Auto-derive the bridged specifiers from the host remoteEntry's shared
+ * singletons instead of listing them by hand. Each derived specifier is loaded
+ * in the host realm (so the captured instance is the host's) and published.
+ */
+export type HostInstancesAuto = {
+  /** Only bridge specifiers matching one of these (exact or prefix, e.g. `'@angular/'`). */
+  include?: string[];
+  /** Never bridge specifiers matching one of these (exact or prefix). */
+  exclude?: string[];
+  /**
+   * How to load each instance. Default: `(s) => import(s)`.
+   *
+   * The default resolves wherever this library runs. Under a bundler-driven dev
+   * server (e.g. Vite SSR) that may NOT be the realm holding the host's running
+   * instance — pass a `load` defined in your own host entry so the import
+   * resolves through the host's module graph and captures the real instance.
+   */
+  load?: (specifier: string) => Promise<object>;
+};
+
+export type HostInstancesOption =
+  /** Explicit map of specifier → already-loaded namespace. */
+  | HostInstanceMap
+  /** Auto-derive every shared singleton from the host remoteEntry. */
+  | 'all'
+  /** Auto-derive, filtered. */
+  | HostInstancesAuto;
+
+type Deps = {
+  remoteEntryProvider: ForProvidingRemoteEntries;
+  hostRemoteEntry: HostOptions['hostRemoteEntry'];
+  log: LogHandler;
+};
+
+/** A pattern matches a specifier on exact equality or as a prefix. */
+const matches = (specifier: string, patterns: string[]): boolean =>
+  patterns.some(p => specifier === p || specifier.startsWith(p));
+
+/** Distinguish the auto forms (`'all'` / filter object) from an explicit map. */
+const isAuto = (option: HostInstancesOption): option is 'all' | HostInstancesAuto =>
+  option === 'all' ||
+  (typeof option === 'object' &&
+    option !== null &&
+    ('include' in option || 'exclude' in option || 'load' in option));
+
+/**
+ * Turn the `hostInstances` option into a concrete `{ specifier: namespace }` map.
+ *
+ * - Explicit map → returned as-is.
+ * - `'all'` / `{ include, exclude }` → read the host remoteEntry's shared
+ *   singletons, apply the filter, and import each in the host realm.
+ *
+ * A specifier that fails to load is skipped with a warning rather than aborting
+ * init — the remote falls back to import-map resolution for it (which is the
+ * pre-bridge behaviour).
+ */
+export const resolveHostInstances = async (
+  option: HostInstancesOption | undefined,
+  deps: Deps
+): Promise<HostInstanceMap | undefined> => {
+  if (!option) return undefined;
+  if (!isAuto(option)) return option;
+
+  const auto: HostInstancesAuto = option === 'all' ? {} : option;
+
+  const { hostRemoteEntry } = deps;
+  if (!hostRemoteEntry) {
+    deps.log.warn(
+      0,
+      '[native-federation] hostInstances auto mode needs a hostRemoteEntry to derive shared singletons from; skipping.'
+    );
+    return undefined;
+  }
+
+  const url = typeof hostRemoteEntry === 'string' ? hostRemoteEntry : hostRemoteEntry.url;
+  const integrity = typeof hostRemoteEntry === 'string' ? undefined : hostRemoteEntry.integrity;
+  const entry = await deps.remoteEntryProvider.provide(url, { integrity });
+
+  const load = auto.load ?? ((specifier: string) => import(specifier));
+
+  const specifiers = [...new Set((entry.shared ?? []).filter(s => s.singleton).map(s => s.packageName))]
+    .filter(s => (auto.include ? matches(s, auto.include) : true))
+    .filter(s => (auto.exclude ? !matches(s, auto.exclude) : true));
+
+  const map: HostInstanceMap = {};
+  for (const specifier of specifiers) {
+    try {
+      map[specifier] = (await load(specifier)) as object;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      deps.log.warn(
+        0,
+        `[native-federation] hostInstances: could not load '${specifier}' from the host realm; skipping (${msg})`
+      );
+    }
+  }
+
+  deps.log.debug(0, `[native-federation] hostInstances bridged: ${Object.keys(map).join(', ') || '(none)'}`);
+  return map;
+};

--- a/src/lib/4.config/import-map/use-node.ts
+++ b/src/lib/4.config/import-map/use-node.ts
@@ -3,12 +3,12 @@ import type { ImportMapConfig } from 'lib/2.app/config/import-map.contract';
 import {
   getNodeLoaderClient,
   type NodeLoaderClient,
-  type ShareScopeKeys,
+  type HostInstanceKeys,
 } from 'lib/3.adapters/node/node-loader.client';
 
 type NodeImportMapConfig = ImportMapConfig & {
   nodeLoader: NodeLoaderClient;
-  setShareScopeFn: (keys: ShareScopeKeys) => Promise<ShareScopeKeys>;
+  setHostInstancesFn: (keys: HostInstanceKeys) => Promise<HostInstanceKeys>;
 };
 
 const useNodeImportMap = (): NodeImportMapConfig => {
@@ -17,7 +17,7 @@ const useNodeImportMap = (): NodeImportMapConfig => {
     nodeLoader,
     loadModuleFn: (url: string) => import(/* @vite-ignore */ url),
     setImportMapFn: (importMap: ImportMap) => nodeLoader.setMap(importMap).then(() => importMap),
-    setShareScopeFn: (keys: ShareScopeKeys) => nodeLoader.setShareScope(keys).then(() => keys),
+    setHostInstancesFn: (keys: HostInstanceKeys) => nodeLoader.setHostInstances(keys).then(() => keys),
     reloadBrowserFn: () => {
       /* no-op */
     },

--- a/src/lib/4.config/import-map/use-node.ts
+++ b/src/lib/4.config/import-map/use-node.ts
@@ -3,14 +3,21 @@ import type { ImportMapConfig } from 'lib/2.app/config/import-map.contract';
 import {
   getNodeLoaderClient,
   type NodeLoaderClient,
+  type ShareScopeKeys,
 } from 'lib/3.adapters/node/node-loader.client';
 
-const useNodeImportMap = (): ImportMapConfig & { nodeLoader: NodeLoaderClient } => {
+type NodeImportMapConfig = ImportMapConfig & {
+  nodeLoader: NodeLoaderClient;
+  setShareScopeFn: (keys: ShareScopeKeys) => Promise<ShareScopeKeys>;
+};
+
+const useNodeImportMap = (): NodeImportMapConfig => {
   const nodeLoader = getNodeLoaderClient();
   return {
     nodeLoader,
     loadModuleFn: (url: string) => import(/* @vite-ignore */ url),
     setImportMapFn: (importMap: ImportMap) => nodeLoader.setMap(importMap).then(() => importMap),
+    setShareScopeFn: (keys: ShareScopeKeys) => nodeLoader.setShareScope(keys).then(() => keys),
     reloadBrowserFn: () => {
       /* no-op */
     },

--- a/src/lib/init-federation.node.ts
+++ b/src/lib/init-federation.node.ts
@@ -23,7 +23,28 @@ import {
 import { useNodeImportMap } from './4.config/import-map/use-node';
 import { normalizeHostRemoteEntry } from './utils/node/to-url';
 
-export type InitNodeFederationOptions = NFOptions;
+export type InitNodeFederationOptions = NFOptions & {
+  /**
+   * Bridge specifiers to instances already loaded in the host process (dev).
+   *
+   * Maps each specifier to its module namespace object — e.g.
+   * `{ '@angular/core': await import('@angular/core') }`. The host's instances
+   * are published on `globalThis.__NF_SHARE_SCOPE__` and the node loader
+   * synthesizes a re-export module for each specifier instead of resolving it
+   * through the import map, so remotes share the host's singletons.
+   *
+   * Exports are value snapshots, not live bindings — fine for packages whose
+   * exports are stable refs (Angular's classes/functions), not for packages
+   * that reassign their exports after init.
+   *
+   * Omit in production: with no `shareScope`, nothing is published and the
+   * loader never routes to the bridge — resolution is import-map only.
+   */
+  shareScope?: Record<string, object>;
+};
+
+/** Global key the node loader reads at module-eval time on the main thread. */
+const SHARE_SCOPE_GLOBAL = '__NF_SHARE_SCOPE__';
 
 const buildNodeAdapters = (config: ConfigContract): DrivingContract => ({
   versionCheck: createVersionCheck(),
@@ -42,6 +63,24 @@ const initNodeFederation = (
   options: InitNodeFederationOptions = {}
 ): Promise<NativeFederationResult> => {
   const nodeConfig = useNodeImportMap();
+
+  // Share-scope bridge (dev): publish the host's instances on the global the
+  // loader reads, then ship the export-key lists to the loader thread and wait
+  // for its ack before the init flow resolves any remote import. With no
+  // shareScope this is a no-op and resolution stays import-map only.
+  let shareScopeReady: Promise<unknown> = Promise.resolve();
+  if (options.shareScope) {
+    const globals = globalThis as Record<string, unknown>;
+    globals[SHARE_SCOPE_GLOBAL] = {
+      ...((globals[SHARE_SCOPE_GLOBAL] as Record<string, object> | undefined) ?? {}),
+      ...options.shareScope,
+    };
+    const keys = Object.fromEntries(
+      Object.entries(options.shareScope).map(([specifier, ns]) => [specifier, Object.keys(ns)])
+    );
+    shareScopeReady = nodeConfig.setShareScopeFn(keys);
+  }
+
   const config = createConfigHandlers({
     ...options,
     hostRemoteEntry: normalizeHostRemoteEntry(options.hostRemoteEntry),
@@ -68,7 +107,8 @@ const initNodeFederation = (
   const initFlow = createInitFlow(INIT_FLOW_FACTORY({ adapters, config }));
   const dynamicInitFlow = createDynamicInitFlow(DYNAMIC_INIT_FLOW_FACTORY({ config, adapters }));
 
-  return initFlow(remotesOrManifestUrl)
+  return shareScopeReady
+    .then(() => initFlow(remotesOrManifestUrl))
     .then(({ loadRemoteModule }) => nodeConfig.nodeLoader.ready().then(() => loadRemoteModule))
     .then(loadRemoteModule => {
       const output = {

--- a/src/lib/init-federation.node.ts
+++ b/src/lib/init-federation.node.ts
@@ -21,30 +21,42 @@ import {
   DYNAMIC_INIT_FLOW_FACTORY,
 } from './5.di/flows/dynamic-init.factory';
 import { useNodeImportMap } from './4.config/import-map/use-node';
+import {
+  resolveHostInstances,
+  type HostInstancesOption,
+} from './4.config/import-map/resolve-host-instances';
 import { normalizeHostRemoteEntry } from './utils/node/to-url';
+
+export type { HostInstancesOption, HostInstancesAuto } from './4.config/import-map/resolve-host-instances';
 
 export type InitNodeFederationOptions = NFOptions & {
   /**
    * Bridge specifiers to instances already loaded in the host process (dev).
    *
-   * Maps each specifier to its module namespace object — e.g.
-   * `{ '@angular/core': await import('@angular/core') }`. The host's instances
-   * are published on `globalThis.__NF_SHARE_SCOPE__` and the node loader
-   * synthesizes a re-export module for each specifier instead of resolving it
-   * through the import map, so remotes share the host's singletons.
+   * The host's instances are published on `globalThis.__NF_HOST_INSTANCES__`
+   * and the node loader synthesizes a re-export module for each specifier
+   * instead of resolving it through the import map, so remotes share the host's
+   * singletons. Three forms:
    *
-   * Exports are value snapshots, not live bindings — fine for packages whose
-   * exports are stable refs (Angular's classes/functions), not for packages
-   * that reassign their exports after init.
+   * - **Explicit map** — `{ '@angular/core': await import('@angular/core') }`.
+   * - **`'all'`** — auto-derive every shared singleton from the host remoteEntry
+   *   and import each in the host realm. Needs `hostRemoteEntry`.
+   * - **`{ include, exclude }`** — auto-derive, filtered by exact/prefix match,
+   *   e.g. `{ include: ['@angular/', 'rxjs', 'zone.js'] }`.
    *
-   * Omit in production: with no `shareScope`, nothing is published and the
+   * This is an escape hatch that bypasses the version resolver, the import map,
+   * and integrity checks entirely. Exports are value snapshots, not live
+   * bindings — fine for packages whose exports are stable refs (Angular's
+   * classes/functions), not for packages that reassign their exports after init.
+   *
+   * Omit in production: with no `hostInstances`, nothing is published and the
    * loader never routes to the bridge — resolution is import-map only.
    */
-  shareScope?: Record<string, object>;
+  hostInstances?: HostInstancesOption;
 };
 
 /** Global key the node loader reads at module-eval time on the main thread. */
-const SHARE_SCOPE_GLOBAL = '__NF_SHARE_SCOPE__';
+const HOST_INSTANCES_GLOBAL = '__NF_HOST_INSTANCES__';
 
 const buildNodeAdapters = (config: ConfigContract): DrivingContract => ({
   versionCheck: createVersionCheck(),
@@ -64,26 +76,11 @@ const initNodeFederation = (
 ): Promise<NativeFederationResult> => {
   const nodeConfig = useNodeImportMap();
 
-  // Share-scope bridge (dev): publish the host's instances on the global the
-  // loader reads, then ship the export-key lists to the loader thread and wait
-  // for its ack before the init flow resolves any remote import. With no
-  // shareScope this is a no-op and resolution stays import-map only.
-  let shareScopeReady: Promise<unknown> = Promise.resolve();
-  if (options.shareScope) {
-    const globals = globalThis as Record<string, unknown>;
-    globals[SHARE_SCOPE_GLOBAL] = {
-      ...((globals[SHARE_SCOPE_GLOBAL] as Record<string, object> | undefined) ?? {}),
-      ...options.shareScope,
-    };
-    const keys = Object.fromEntries(
-      Object.entries(options.shareScope).map(([specifier, ns]) => [specifier, Object.keys(ns)])
-    );
-    shareScopeReady = nodeConfig.setShareScopeFn(keys);
-  }
+  const hostRemoteEntry = normalizeHostRemoteEntry(options.hostRemoteEntry);
 
   const config = createConfigHandlers({
     ...options,
-    hostRemoteEntry: normalizeHostRemoteEntry(options.hostRemoteEntry),
+    hostRemoteEntry,
     loadModuleFn: options.loadModuleFn ?? nodeConfig.loadModuleFn,
     setImportMapFn: options.setImportMapFn ?? nodeConfig.setImportMapFn,
     reloadBrowserFn: options.reloadBrowserFn ?? nodeConfig.reloadBrowserFn,
@@ -91,6 +88,30 @@ const initNodeFederation = (
   });
 
   const adapters = buildNodeAdapters(config);
+
+  // Host-instance bridge (dev): resolve the instance map (explicit, or
+  // auto-derived from the host remoteEntry's shared singletons), publish it on
+  // the global the loader reads, ship the export-key lists to the loader thread,
+  // and wait for its ack before the init flow resolves any remote import. With
+  // no hostInstances this is a no-op and resolution stays import-map only.
+  const hostInstancesReady = (async () => {
+    const instances = await resolveHostInstances(options.hostInstances, {
+      remoteEntryProvider: adapters.remoteEntryProvider,
+      hostRemoteEntry,
+      log: config.log,
+    });
+    if (!instances || Object.keys(instances).length === 0) return;
+
+    const globals = globalThis as Record<string, unknown>;
+    globals[HOST_INSTANCES_GLOBAL] = {
+      ...((globals[HOST_INSTANCES_GLOBAL] as Record<string, object> | undefined) ?? {}),
+      ...instances,
+    };
+    const keys = Object.fromEntries(
+      Object.entries(instances).map(([specifier, ns]) => [specifier, Object.keys(ns)])
+    );
+    await nodeConfig.setHostInstancesFn(keys);
+  })();
 
   const stateDump = (msg: string) =>
     config.log.debug(0, msg, {
@@ -107,7 +128,7 @@ const initNodeFederation = (
   const initFlow = createInitFlow(INIT_FLOW_FACTORY({ adapters, config }));
   const dynamicInitFlow = createDynamicInitFlow(DYNAMIC_INIT_FLOW_FACTORY({ config, adapters }));
 
-  return shareScopeReady
+  return hostInstancesReady
     .then(() => initFlow(remotesOrManifestUrl))
     .then(({ loadRemoteModule }) => nodeConfig.nodeLoader.ready().then(() => loadRemoteModule))
     .then(loadRemoteModule => {

--- a/src/node-loader.spec.ts
+++ b/src/node-loader.spec.ts
@@ -67,6 +67,16 @@ describe('node-loader hooks', () => {
       expect(next).toHaveBeenCalledWith('file:///live.mjs', {});
     });
 
+    it('acks set-share-scope with share-scope-applied', () => {
+      const loader = freshLoader();
+      const port = new FakePort();
+      loader.initialize({ port: port as unknown as EventEmitter & { postMessage(m: unknown): void } });
+
+      port.emit({ type: 'set-share-scope', keys: { '@angular/core': ['Component'] } });
+
+      expect(port.postMessage).toHaveBeenCalledWith({ type: 'share-scope-applied' });
+    });
+
     it('ignores port messages of other types', async () => {
       const loader = freshLoader();
       const port = new FakePort();
@@ -156,6 +166,77 @@ describe('node-loader hooks', () => {
       expect(next).toHaveBeenCalledWith('file:///globals/lib.mjs', {
         parentURL: 'file:///apps/b/entry.mjs',
       });
+    });
+  });
+
+  describe('share scope', () => {
+    const withScope = (keys: Record<string, string[]>): LoaderModule => {
+      const loader = freshLoader();
+      const port = new FakePort();
+      loader.initialize({ port: port as unknown as EventEmitter & { postMessage(m: unknown): void } });
+      port.emit({ type: 'set-share-scope', keys });
+      return loader;
+    };
+
+    it('routes a bridged specifier to a synthetic nf-share: URL, bypassing nextResolve', async () => {
+      const loader = withScope({ '@angular/core': ['Component'] });
+      const next = jest.fn();
+
+      const result = await loader.resolve('@angular/core', {}, next);
+
+      expect(result).toEqual({ url: 'nf-share:%40angular%2Fcore', shortCircuit: true });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('bridged specifiers win over the import map', async () => {
+      const loader = freshLoader();
+      const port = new FakePort();
+      loader.initialize({ port: port as unknown as EventEmitter & { postMessage(m: unknown): void } });
+      port.emit({ type: 'set-import-map', map: { imports: { '@angular/core': 'file:///ng.mjs' } } });
+      port.emit({ type: 'set-share-scope', keys: { '@angular/core': ['Component'] } });
+      const next = jest.fn();
+
+      const result = await loader.resolve('@angular/core', {}, next);
+
+      expect(result.url).toBe('nf-share:%40angular%2Fcore');
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('synthesizes a module that re-exports named keys and default from the global scope', async () => {
+      const loader = withScope({ '@angular/core': ['Component', 'default', 'ɵsetClassMetadata'] });
+
+      const result = await loader.load('nf-share:%40angular%2Fcore', {}, jest.fn());
+
+      expect(result.shortCircuit).toBe(true);
+      expect(result.format).toBe('module');
+      const source = result.source as string;
+      expect(source).toContain('globalThis["__NF_SHARE_SCOPE__"]["@angular/core"]');
+      expect(source).toContain('export const Component = __ns["Component"];');
+      expect(source).toContain('export const ɵsetClassMetadata = __ns["ɵsetClassMetadata"];');
+      expect(source).toContain('export default __ns["default"];');
+      // `default` must not also be emitted as a named const.
+      expect(source).not.toContain('export const default');
+    });
+
+    it('throws a clear error at eval time when the namespace is not published', async () => {
+      const loader = withScope({ '@angular/core': ['Component'] });
+      const result = await loader.load('nf-share:%40angular%2Fcore', {}, jest.fn());
+      const source = result.source as string;
+
+      expect(source).toContain(
+        `throw new Error("[native-federation] share scope '@angular/core' not published")`
+      );
+    });
+
+    it('skips export names that are not valid identifiers', async () => {
+      const loader = withScope({ pkg: ['ok', 'has-dash', '1bad'] });
+
+      const result = await loader.load('nf-share:pkg', {}, jest.fn());
+      const source = result.source as string;
+
+      expect(source).toContain('export const ok = __ns["ok"];');
+      expect(source).not.toContain('has-dash');
+      expect(source).not.toContain('1bad');
     });
   });
 

--- a/src/node-loader.spec.ts
+++ b/src/node-loader.spec.ts
@@ -67,14 +67,14 @@ describe('node-loader hooks', () => {
       expect(next).toHaveBeenCalledWith('file:///live.mjs', {});
     });
 
-    it('acks set-share-scope with share-scope-applied', () => {
+    it('acks set-host-instances with host-instances-applied', () => {
       const loader = freshLoader();
       const port = new FakePort();
       loader.initialize({ port: port as unknown as EventEmitter & { postMessage(m: unknown): void } });
 
-      port.emit({ type: 'set-share-scope', keys: { '@angular/core': ['Component'] } });
+      port.emit({ type: 'set-host-instances', keys: { '@angular/core': ['Component'] } });
 
-      expect(port.postMessage).toHaveBeenCalledWith({ type: 'share-scope-applied' });
+      expect(port.postMessage).toHaveBeenCalledWith({ type: 'host-instances-applied' });
     });
 
     it('ignores port messages of other types', async () => {
@@ -169,22 +169,22 @@ describe('node-loader hooks', () => {
     });
   });
 
-  describe('share scope', () => {
-    const withScope = (keys: Record<string, string[]>): LoaderModule => {
+  describe('host instances', () => {
+    const withHostInstances = (keys: Record<string, string[]>): LoaderModule => {
       const loader = freshLoader();
       const port = new FakePort();
       loader.initialize({ port: port as unknown as EventEmitter & { postMessage(m: unknown): void } });
-      port.emit({ type: 'set-share-scope', keys });
+      port.emit({ type: 'set-host-instances', keys });
       return loader;
     };
 
-    it('routes a bridged specifier to a synthetic nf-share: URL, bypassing nextResolve', async () => {
-      const loader = withScope({ '@angular/core': ['Component'] });
+    it('routes a bridged specifier to a synthetic nf-host: URL, bypassing nextResolve', async () => {
+      const loader = withHostInstances({ '@angular/core': ['Component'] });
       const next = jest.fn();
 
       const result = await loader.resolve('@angular/core', {}, next);
 
-      expect(result).toEqual({ url: 'nf-share:%40angular%2Fcore', shortCircuit: true });
+      expect(result).toEqual({ url: 'nf-host:%40angular%2Fcore', shortCircuit: true });
       expect(next).not.toHaveBeenCalled();
     });
 
@@ -193,24 +193,24 @@ describe('node-loader hooks', () => {
       const port = new FakePort();
       loader.initialize({ port: port as unknown as EventEmitter & { postMessage(m: unknown): void } });
       port.emit({ type: 'set-import-map', map: { imports: { '@angular/core': 'file:///ng.mjs' } } });
-      port.emit({ type: 'set-share-scope', keys: { '@angular/core': ['Component'] } });
+      port.emit({ type: 'set-host-instances', keys: { '@angular/core': ['Component'] } });
       const next = jest.fn();
 
       const result = await loader.resolve('@angular/core', {}, next);
 
-      expect(result.url).toBe('nf-share:%40angular%2Fcore');
+      expect(result.url).toBe('nf-host:%40angular%2Fcore');
       expect(next).not.toHaveBeenCalled();
     });
 
-    it('synthesizes a module that re-exports named keys and default from the global scope', async () => {
-      const loader = withScope({ '@angular/core': ['Component', 'default', 'ɵsetClassMetadata'] });
+    it('synthesizes a module that re-exports named keys and default from the host instances', async () => {
+      const loader = withHostInstances({ '@angular/core': ['Component', 'default', 'ɵsetClassMetadata'] });
 
-      const result = await loader.load('nf-share:%40angular%2Fcore', {}, jest.fn());
+      const result = await loader.load('nf-host:%40angular%2Fcore', {}, jest.fn());
 
       expect(result.shortCircuit).toBe(true);
       expect(result.format).toBe('module');
       const source = result.source as string;
-      expect(source).toContain('globalThis["__NF_SHARE_SCOPE__"]["@angular/core"]');
+      expect(source).toContain('globalThis["__NF_HOST_INSTANCES__"]["@angular/core"]');
       expect(source).toContain('export const Component = __ns["Component"];');
       expect(source).toContain('export const ɵsetClassMetadata = __ns["ɵsetClassMetadata"];');
       expect(source).toContain('export default __ns["default"];');
@@ -219,19 +219,19 @@ describe('node-loader hooks', () => {
     });
 
     it('throws a clear error at eval time when the namespace is not published', async () => {
-      const loader = withScope({ '@angular/core': ['Component'] });
-      const result = await loader.load('nf-share:%40angular%2Fcore', {}, jest.fn());
+      const loader = withHostInstances({ '@angular/core': ['Component'] });
+      const result = await loader.load('nf-host:%40angular%2Fcore', {}, jest.fn());
       const source = result.source as string;
 
       expect(source).toContain(
-        `throw new Error("[native-federation] share scope '@angular/core' not published")`
+        `throw new Error("[native-federation] host instance '@angular/core' not published")`
       );
     });
 
     it('skips export names that are not valid identifiers', async () => {
-      const loader = withScope({ pkg: ['ok', 'has-dash', '1bad'] });
+      const loader = withHostInstances({ pkg: ['ok', 'has-dash', '1bad'] });
 
-      const result = await loader.load('nf-share:pkg', {}, jest.fn());
+      const result = await loader.load('nf-host:pkg', {}, jest.fn());
       const source = result.source as string;
 
       expect(source).toContain('export const ok = __ns["ok"];');

--- a/src/node-loader.ts
+++ b/src/node-loader.ts
@@ -13,8 +13,8 @@ type Imports = Record<string, string>;
 type Scopes = Record<string, Imports>;
 type ImportMap = { imports: Imports; scopes?: Scopes };
 
-/** Per-specifier list of export names to re-export from the published share scope. */
-type ShareScopeKeys = Record<string, string[]>;
+/** Per-specifier list of export names to re-export from the host's published instances. */
+type HostInstanceKeys = Record<string, string[]>;
 
 type InitData = {
   port?: MessagePort;
@@ -23,14 +23,14 @@ type InitData = {
 
 type IncomingMessage =
   | { type: 'set-import-map'; map: ImportMap }
-  | { type: 'set-share-scope'; keys?: ShareScopeKeys };
+  | { type: 'set-host-instances'; keys?: HostInstanceKeys };
 
 const EMPTY_MAP: ImportMap = Object.freeze({ imports: {}, scopes: {} });
 
-/** Synthetic URL scheme for specifiers bridged to the host's share scope. */
-const SHARE_PREFIX = 'nf-share:';
+/** Synthetic URL scheme for specifiers bridged to the host's instances. */
+const HOST_PREFIX = 'nf-host:';
 /** Global key on the main thread holding `{ [specifier]: namespaceObject }`. */
-const SHARE_SCOPE_GLOBAL = '__NF_SHARE_SCOPE__';
+const HOST_INSTANCES_GLOBAL = '__NF_HOST_INSTANCES__';
 
 const baseURL = (() => {
   const cwd = process.cwd();
@@ -40,7 +40,7 @@ const baseURL = (() => {
 })();
 
 let activeMap: ImportMap = EMPTY_MAP;
-let shareScopeKeys: ShareScopeKeys = Object.create(null);
+let hostInstanceKeys: HostInstanceKeys = Object.create(null);
 
 export function initialize(data: InitData = {}): void {
   if (data.initialImportMap) {
@@ -51,9 +51,9 @@ export function initialize(data: InitData = {}): void {
       if (msg && msg.type === 'set-import-map') {
         activeMap = normalize(msg.map);
         data.port!.postMessage({ type: 'import-map-applied' });
-      } else if (msg && msg.type === 'set-share-scope') {
-        shareScopeKeys = msg.keys ?? Object.create(null);
-        data.port!.postMessage({ type: 'share-scope-applied' });
+      } else if (msg && msg.type === 'set-host-instances') {
+        hostInstanceKeys = msg.keys ?? Object.create(null);
+        data.port!.postMessage({ type: 'host-instances-applied' });
       }
     });
     data.port.unref?.();
@@ -70,9 +70,9 @@ export async function resolve(
   nextResolve: NextResolve
 ): Promise<ResolveResult> {
   // Bridged specifiers win over the import map: route them to a synthetic
-  // module that re-exports from the host's published share scope.
-  if (Object.prototype.hasOwnProperty.call(shareScopeKeys, specifier)) {
-    return { url: SHARE_PREFIX + encodeURIComponent(specifier), shortCircuit: true };
+  // module that re-exports from the host's published instances.
+  if (Object.prototype.hasOwnProperty.call(hostInstanceKeys, specifier)) {
+    return { url: HOST_PREFIX + encodeURIComponent(specifier), shortCircuit: true };
   }
   const mapped = resolveSpecifier(activeMap, specifier, context.parentURL);
   return nextResolve(mapped ?? specifier, context);
@@ -91,12 +91,12 @@ export async function load(
   context: LoadContext,
   nextLoad: NextLoad
 ): Promise<LoadResult> {
-  if (url.startsWith(SHARE_PREFIX)) {
-    const specifier = decodeURIComponent(url.slice(SHARE_PREFIX.length));
+  if (url.startsWith(HOST_PREFIX)) {
+    const specifier = decodeURIComponent(url.slice(HOST_PREFIX.length));
     return {
       shortCircuit: true,
       format: 'module',
-      source: synthShareModule(specifier, shareScopeKeys[specifier]),
+      source: synthHostModule(specifier, hostInstanceKeys[specifier]),
     };
   }
   if (url.startsWith('http://') || url.startsWith('https://')) {
@@ -113,21 +113,21 @@ export async function load(
   return nextLoad(url, context);
 }
 
-// --- share-scope bridge ----------------------------------------------------
+// --- host-instance bridge --------------------------------------------------
 // Synthesizes an in-memory ESM module whose exports forward to the namespace
-// the host published on `globalThis[SHARE_SCOPE_GLOBAL]`. The export-key list
-// is computed on the main thread (where the namespace lives) and shipped over
-// the port, so the loader realm never has to enumerate a namespace it can't
-// see. The `globalThis[...]` reads below run at module-eval time on the main
-// thread, where the instances actually exist.
+// the host published on `globalThis[HOST_INSTANCES_GLOBAL]`. The export-key
+// list is computed on the main thread (where the namespace lives) and shipped
+// over the port, so the loader realm never has to enumerate a namespace it
+// can't see. The `globalThis[...]` reads below run at module-eval time on the
+// main thread, where the instances actually exist.
 
-function synthShareModule(specifier: string, keys: string[] | undefined): string {
+function synthHostModule(specifier: string, keys: string[] | undefined): string {
   const ID = /^[\p{ID_Start}$_][\p{ID_Continue}$]*$/u;
-  const ref = `globalThis[${JSON.stringify(SHARE_SCOPE_GLOBAL)}][${JSON.stringify(specifier)}]`;
+  const ref = `globalThis[${JSON.stringify(HOST_INSTANCES_GLOBAL)}][${JSON.stringify(specifier)}]`;
   const lines = [
     `const __ns = ${ref};`,
     `if (!__ns) throw new Error(${JSON.stringify(
-      `[native-federation] share scope '${specifier}' not published`
+      `[native-federation] host instance '${specifier}' not published`
     )});`,
   ];
   let hasDefault = false;

--- a/src/node-loader.ts
+++ b/src/node-loader.ts
@@ -13,12 +13,24 @@ type Imports = Record<string, string>;
 type Scopes = Record<string, Imports>;
 type ImportMap = { imports: Imports; scopes?: Scopes };
 
+/** Per-specifier list of export names to re-export from the published share scope. */
+type ShareScopeKeys = Record<string, string[]>;
+
 type InitData = {
   port?: MessagePort;
   initialImportMap?: ImportMap;
 };
 
+type IncomingMessage =
+  | { type: 'set-import-map'; map: ImportMap }
+  | { type: 'set-share-scope'; keys?: ShareScopeKeys };
+
 const EMPTY_MAP: ImportMap = Object.freeze({ imports: {}, scopes: {} });
+
+/** Synthetic URL scheme for specifiers bridged to the host's share scope. */
+const SHARE_PREFIX = 'nf-share:';
+/** Global key on the main thread holding `{ [specifier]: namespaceObject }`. */
+const SHARE_SCOPE_GLOBAL = '__NF_SHARE_SCOPE__';
 
 const baseURL = (() => {
   const cwd = process.cwd();
@@ -28,16 +40,20 @@ const baseURL = (() => {
 })();
 
 let activeMap: ImportMap = EMPTY_MAP;
+let shareScopeKeys: ShareScopeKeys = Object.create(null);
 
 export function initialize(data: InitData = {}): void {
   if (data.initialImportMap) {
     activeMap = normalize(data.initialImportMap);
   }
   if (data.port) {
-    data.port.on('message', (msg: { type: 'set-import-map'; map: ImportMap }) => {
+    data.port.on('message', (msg: IncomingMessage) => {
       if (msg && msg.type === 'set-import-map') {
         activeMap = normalize(msg.map);
         data.port!.postMessage({ type: 'import-map-applied' });
+      } else if (msg && msg.type === 'set-share-scope') {
+        shareScopeKeys = msg.keys ?? Object.create(null);
+        data.port!.postMessage({ type: 'share-scope-applied' });
       }
     });
     data.port.unref?.();
@@ -53,6 +69,11 @@ export async function resolve(
   context: ResolveContext,
   nextResolve: NextResolve
 ): Promise<ResolveResult> {
+  // Bridged specifiers win over the import map: route them to a synthetic
+  // module that re-exports from the host's published share scope.
+  if (Object.prototype.hasOwnProperty.call(shareScopeKeys, specifier)) {
+    return { url: SHARE_PREFIX + encodeURIComponent(specifier), shortCircuit: true };
+  }
   const mapped = resolveSpecifier(activeMap, specifier, context.parentURL);
   return nextResolve(mapped ?? specifier, context);
 }
@@ -70,6 +91,14 @@ export async function load(
   context: LoadContext,
   nextLoad: NextLoad
 ): Promise<LoadResult> {
+  if (url.startsWith(SHARE_PREFIX)) {
+    const specifier = decodeURIComponent(url.slice(SHARE_PREFIX.length));
+    return {
+      shortCircuit: true,
+      format: 'module',
+      source: synthShareModule(specifier, shareScopeKeys[specifier]),
+    };
+  }
   if (url.startsWith('http://') || url.startsWith('https://')) {
     const res = await fetch(url);
     if (!res.ok) {
@@ -82,6 +111,37 @@ export async function load(
     context.format = 'module';
   }
   return nextLoad(url, context);
+}
+
+// --- share-scope bridge ----------------------------------------------------
+// Synthesizes an in-memory ESM module whose exports forward to the namespace
+// the host published on `globalThis[SHARE_SCOPE_GLOBAL]`. The export-key list
+// is computed on the main thread (where the namespace lives) and shipped over
+// the port, so the loader realm never has to enumerate a namespace it can't
+// see. The `globalThis[...]` reads below run at module-eval time on the main
+// thread, where the instances actually exist.
+
+function synthShareModule(specifier: string, keys: string[] | undefined): string {
+  const ID = /^[\p{ID_Start}$_][\p{ID_Continue}$]*$/u;
+  const ref = `globalThis[${JSON.stringify(SHARE_SCOPE_GLOBAL)}][${JSON.stringify(specifier)}]`;
+  const lines = [
+    `const __ns = ${ref};`,
+    `if (!__ns) throw new Error(${JSON.stringify(
+      `[native-federation] share scope '${specifier}' not published`
+    )});`,
+  ];
+  let hasDefault = false;
+  for (const k of keys ?? []) {
+    if (k === 'default') {
+      hasDefault = true;
+      continue;
+    }
+    // Defensive: only emit syntactically valid export identifiers. Angular's
+    // ɵ… names pass \p{ID_Start}; anything else is skipped.
+    if (ID.test(k)) lines.push(`export const ${k} = __ns[${JSON.stringify(k)}];`);
+  }
+  if (hasDefault) lines.push(`export default __ns["default"];`);
+  return lines.join('\n') + '\n';
 }
 
 // --- WICG import-map resolve algorithm ------------------------------------


### PR DESCRIPTION
Closes #20 

This pull request introduces support for sharing the host application's loaded module instances (such as Angular core libraries) with remote modules in Node.js development environments. This is achieved via a new `hostInstances` option and a coordinated mechanism between the host and the Node loader, ensuring that singletons are preserved and remotes use the host's already-loaded modules. The implementation includes updates to the loader protocol, initialization logic, and comprehensive tests.

The most important changes are:

**Host Instance Sharing Mechanism:**
* Added a new `hostInstances` option to `initNodeFederation` that allows the host to publish already-loaded module instances (e.g., `@angular/core`) for remotes to re-use, bypassing the import map and version checks. The host publishes these on `globalThis.__NF_HOST_INSTANCES__`, and the loader creates synthetic modules that re-export the specified exports. This prevents multiple copies of singletons in development. [[1]](diffhunk://#diff-adae49530b8cae096a0fc6a1ef669b51df382ba7fbc5cae4512fd157ca8625beL26-R48) [[2]](diffhunk://#diff-adae49530b8cae096a0fc6a1ef669b51df382ba7fbc5cae4512fd157ca8625beR67-R84) [[3]](diffhunk://#diff-adae49530b8cae096a0fc6a1ef669b51df382ba7fbc5cae4512fd157ca8625beL71-R112) [[4]](diffhunk://#diff-0c98376eb7ce122aa136f768701a6528930b3a02f8e4b6f7380e44669a04b79fR171-R210)

**Node Loader Protocol and Logic:**
* Extended the loader-client and loader protocol to support a new `set-host-instances` message, including serialization, acknowledgment (`host-instances-applied`), and strict sequencing with import map updates. The loader now recognizes bridged specifiers and routes them to synthetic modules. [[1]](diffhunk://#diff-612c807e8373f9e86b2f7a2af7c28fba0a3d8d68fca46e958f9186ca4c11b561L6-R16) [[2]](diffhunk://#diff-612c807e8373f9e86b2f7a2af7c28fba0a3d8d68fca46e958f9186ca4c11b561L30-R47) [[3]](diffhunk://#diff-612c807e8373f9e86b2f7a2af7c28fba0a3d8d68fca46e958f9186ca4c11b561L48-R86) [[4]](diffhunk://#diff-8b0f12df60bf7a33dcd68ab9a78662ace3ae21dadcb33e89b2d0964849766a61R6-R20) [[5]](diffhunk://#diff-6f9aeb0c3ebacb976cf39b41a8431bfa46f785716dbb0105e27e69a03bdcc5e5R16-R34) [[6]](diffhunk://#diff-6f9aeb0c3ebacb976cf39b41a8431bfa46f785716dbb0105e27e69a03bdcc5e5R43-R56) [[7]](diffhunk://#diff-6f9aeb0c3ebacb976cf39b41a8431bfa46f785716dbb0105e27e69a03bdcc5e5R72-R76)

**Synthetic Module Generation:**
* Implemented logic in the loader to synthesize ESM modules at runtime that re-export only the specified export names from the host's published namespace object. Handles default exports and skips invalid identifiers. Throws a clear error if the namespace is missing. [[1]](diffhunk://#diff-6f9aeb0c3ebacb976cf39b41a8431bfa46f785716dbb0105e27e69a03bdcc5e5R94-R101) [[2]](diffhunk://#diff-6f9aeb0c3ebacb976cf39b41a8431bfa46f785716dbb0105e27e69a03bdcc5e5R116-R146)

**Testing and Validation:**
* Added comprehensive tests for the new host instance bridging, covering message sequencing, synthetic module generation, error handling, and precedence over the import map. [[1]](diffhunk://#diff-11d016ab58bb731afb95f0552d29f3203834d510088503e7feb8e68e958034f5R107-R168) [[2]](diffhunk://#diff-d26231bb0bbb3fcf3aa1692a896779edfe2428ea9c1a8a23a4f34df173d7c052R70-R79) [[3]](diffhunk://#diff-d26231bb0bbb3fcf3aa1692a896779edfe2428ea9c1a8a23a4f34df173d7c052R172-R242)

**Documentation:**
* Updated documentation to explain the new `hostInstances` option, its intended use in development, and caveats regarding singleton preservation and bypassing of version/integrity checks.

These changes collectively enable seamless singleton sharing between host and remotes in Node.js dev mode, improving developer experience and reliability.